### PR TITLE
Some samples default to different iModels

### DIFF
--- a/src/Components/SampleShowcase/SampleShowcase.tsx
+++ b/src/Components/SampleShowcase/SampleShowcase.tsx
@@ -95,13 +95,12 @@ export class SampleShowcase extends React.Component<{}, ShowcaseState> {
     return customModelList ? customModelList : IModelSelector.defaultIModelList;
   }
 
-  private getIModelSelector(sampleGroup: string, sampleName: string): React.ReactNode {
-    const activeSample = this.getSampleByName(sampleGroup, sampleName);
-    const modelList = activeSample ? this.getIModelList(activeSample) : null;
-    if (modelList && 1 < modelList.length)
-      return (<div className="model-selector">
-        <IModelSelector iModelNames={modelList} iModelName={this.state.iModelName} onIModelChange={this.onIModelChange} />
-      </div>);
+  private getIModelSelector(iModelName: string, iModelList: string[]): React.ReactNode {
+    if (iModelList && 1 < iModelList.length)
+      return (
+        <div className="model-selector">
+          <IModelSelector iModelNames={iModelList} iModelName={iModelName} onIModelChange={this.onIModelChange} />
+        </div>);
   }
 
   private async setupNewSample(groupName: string, sampleName: string) {
@@ -116,11 +115,12 @@ export class SampleShowcase extends React.Component<{}, ShowcaseState> {
     let iModelName = this.state.iModelName;
 
     if (newSampleSpec && newSampleSpec.setup) {
+      const iModelList = this.getIModelList(newSampleSpec);
 
       if (newSampleSpec.name !== this.state.activeSampleName) {
-        iModelName = this.getIModelList(newSampleSpec)[0];
+        iModelName = iModelList[0];
       }
-      sampleUI = await newSampleSpec.setup(iModelName, this.getIModelSelector(groupName, sampleName));
+      sampleUI = await newSampleSpec.setup(iModelName, this.getIModelSelector(iModelName, iModelList));
     }
 
     this.setState({ activeSampleGroup: groupName, activeSampleName: sampleName, sampleUI, iModelName }, () => {

--- a/src/frontend-samples/emphasize-elements-sample/sampleSpec.tsx
+++ b/src/frontend-samples/emphasize-elements-sample/sampleSpec.tsx
@@ -3,6 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../Components/SampleShowcase/SampleShowcase";
+import { SampleIModels } from "../../Components/IModelSelector/IModelSelector";
 import { EmphasizeElementsApp } from ".";
 
 export function getEmphasizeElementsSpec(): SampleSpec {
@@ -14,6 +15,7 @@ export function getEmphasizeElementsSpec(): SampleSpec {
       { name: "EmphasizeElementsSample.tsx", import: import("!!raw-loader!./index") },
       { name: "samples-common.scss", import: import("!!raw-loader!../../common/samples-common.scss") },
     ],
+    customModelList: [SampleIModels.RetailBuilding, SampleIModels.MetroStation, SampleIModels.BayTown, SampleIModels.House],
     setup: EmphasizeElementsApp.setup,
     teardown: EmphasizeElementsApp.teardown,
   });

--- a/src/frontend-samples/thematic-display-sample/sampleSpec.tsx
+++ b/src/frontend-samples/thematic-display-sample/sampleSpec.tsx
@@ -3,6 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../Components/SampleShowcase/SampleShowcase";
+import { SampleIModels } from "../../Components/IModelSelector/IModelSelector";
 import { ThematicDisplaySampleApp } from ".";
 
 export function getThematicDisplaySpec(): SampleSpec {
@@ -14,6 +15,7 @@ export function getThematicDisplaySpec(): SampleSpec {
       { name: "TooltipSample.tsx", import: import("!!raw-loader!./index") },
       { name: "samples-common.scss", import: import("!!raw-loader!../../common/samples-common.scss") },
     ],
+    customModelList: [SampleIModels.RetailBuilding, SampleIModels.MetroStation, SampleIModels.BayTown, SampleIModels.House],
     setup: ThematicDisplaySampleApp.setup,
     teardown: ThematicDisplaySampleApp.teardown,
   });

--- a/src/frontend-samples/view-clip-sample/sampleSpec.tsx
+++ b/src/frontend-samples/view-clip-sample/sampleSpec.tsx
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import { SampleSpec } from "../../Components/SampleShowcase/SampleShowcase";
+import { SampleIModels } from "../../Components/IModelSelector/IModelSelector";
 import { ViewClipUI } from ".";
 
 export function getViewClipSpec(): SampleSpec {
@@ -15,6 +16,7 @@ export function getViewClipSpec(): SampleSpec {
       { name: "ViewClipSample.tsx", import: import("!!raw-loader!./index") },
       { name: "samples-common.scss", import: import("!!raw-loader!../../common/samples-common.scss") },
     ],
+    customModelList: [SampleIModels.RetailBuilding, SampleIModels.MetroStation, SampleIModels.BayTown, SampleIModels.House],
     setup: async (iModelName: string, iModelSelector: React.ReactNode) => {
       return <ViewClipUI iModelName={iModelName} iModelSelector={iModelSelector} />;
     },

--- a/src/frontend-samples/zoom-to-elements-sample/sampleSpec.tsx
+++ b/src/frontend-samples/zoom-to-elements-sample/sampleSpec.tsx
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import React from "react";
 import { SampleSpec } from "../../Components/SampleShowcase/SampleShowcase";
+import { SampleIModels } from "../../Components/IModelSelector/IModelSelector";
 import { ZoomToElementsUI } from ".";
 
 export function getZoomToElementsSpec(): SampleSpec {
@@ -16,6 +17,7 @@ export function getZoomToElementsSpec(): SampleSpec {
       { name: "samples-common.scss", import: import("!!raw-loader!../../common/samples-common.scss") },
       { name: "index.scss", import: import("!!raw-loader!./index.scss") },
     ],
+    customModelList: [SampleIModels.BayTown, SampleIModels.RetailBuilding, SampleIModels.MetroStation, SampleIModels.House],
     setup: async (iModelName: string, iModelSelector: React.ReactNode) => {
       return <ZoomToElementsUI iModelName={iModelName} iModelSelector={iModelSelector} />;
     },


### PR DESCRIPTION
Some samples just look or work better with retail building or baytown.  We want the thumbnails to match with the starting model.
Also, I fixed a small bug with initializing the modelselector.