### PR TITLE
Automatically renew token when close to expiration.

### DIFF
--- a/src/NoSignInIAuthClient.ts
+++ b/src/NoSignInIAuthClient.ts
@@ -52,7 +52,12 @@ export class NoSignInIAuthClient implements FrontendAuthorizationClient {
     this._accessToken = AccessToken.fromJson(tokenJson);
 
     // Automatically renew if session exceeds 55 minutes.
-    setTimeout(() => { this.generateTokenString(userURL) }, (1000 * 60 * 55));
+    setTimeout(() => {
+      this.generateTokenString(userURL)
+        .catch((error) => {
+          throw new BentleyError(AuthStatus.Error, error);
+        });
+    }, (1000 * 60 * 55));
   }
 
   public async getAccessToken(): Promise<AccessToken> {

--- a/src/NoSignInIAuthClient.ts
+++ b/src/NoSignInIAuthClient.ts
@@ -50,6 +50,9 @@ export class NoSignInIAuthClient implements FrontendAuthorizationClient {
       _userInfo: { id: "MockId" },
     };
     this._accessToken = AccessToken.fromJson(tokenJson);
+
+    // Automatically renew if session exceeds 55 minutes.
+    setTimeout(() => { this.generateTokenString(userURL) }, (1000 * 60 * 55));
   }
 
   public async getAccessToken(): Promise<AccessToken> {


### PR DESCRIPTION
We do not have a user manager to automatically handle token renewal. Force the authorization client to renew when close to expiration by requesting a new token.