### PR TITLE
Changed module export for samples to export default

### DIFF
--- a/src/frontend-samples/component-gallery/badge-sample/index.tsx
+++ b/src/frontend-samples/component-gallery/badge-sample/index.tsx
@@ -13,7 +13,7 @@ import { BetaBadge, NewBadge } from "@bentley/ui-core";
 export const createComponentExample = (title: string, description: string | undefined, content: React.ReactNode): ComponentExampleProps => {
   return { title, description, content };
 };
-export class BadgeList extends React.Component<{}> {
+export default class BadgeList extends React.Component<{}> {
 
   // Combines several instances of ComponentExampleProps to be passed into the ComponentContainer
   public static getBadgeData(): ComponentExampleProps[] {

--- a/src/frontend-samples/component-gallery/badge-sample/sampleSpec.tsx
+++ b/src/frontend-samples/component-gallery/badge-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { BadgeList } from ".";
+import BadgeList from ".";
 
 // Provides the information about the sample, passing no iModels since this sample does not utilize any
 export function getBadgeSpec(): SampleSpec {

--- a/src/frontend-samples/component-gallery/button-sample/index.tsx
+++ b/src/frontend-samples/component-gallery/button-sample/index.tsx
@@ -14,7 +14,7 @@ export const createComponentExample = (title: string, description: string | unde
   return { title, description, content };
 };
 
-export class ButtonList extends React.Component<{}> {
+export default class ButtonList extends React.Component<{}> {
 
   // Combines several instances of ComponentExampleProps to be passed into the ComponentContainer
   public static getButtonData(): ComponentExampleProps[] {

--- a/src/frontend-samples/component-gallery/button-sample/sampleSpec.tsx
+++ b/src/frontend-samples/component-gallery/button-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { ButtonList } from ".";
+import ButtonList from ".";
 
 // Provides the information about the sample, passing no iModels since this sample does not utilize any
 export function getButtonSpec(): SampleSpec {

--- a/src/frontend-samples/component-gallery/checklistbox-sample/index.tsx
+++ b/src/frontend-samples/component-gallery/checklistbox-sample/index.tsx
@@ -14,7 +14,7 @@ export const createComponentExample = (title: string, description: string | unde
   return { title, description, content };
 };
 
-export class CheckListBoxList extends React.Component<{}> {
+export default class CheckListBoxList extends React.Component<{}> {
 
   // Combines several instances of ComponentExampleProps to be passed into the ComponentContainer
   public static getCheckListBoxData(): ComponentExampleProps[] {

--- a/src/frontend-samples/component-gallery/checklistbox-sample/sampleSpec.tsx
+++ b/src/frontend-samples/component-gallery/checklistbox-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { CheckListBoxList } from ".";
+import CheckListBoxList from ".";
 
 // Provides the information about the sample, passing no iModels since this sample does not utilize any
 export function getCheckListBoxSpec(): SampleSpec {

--- a/src/frontend-samples/component-gallery/context-menu-sample/index.tsx
+++ b/src/frontend-samples/component-gallery/context-menu-sample/index.tsx
@@ -15,7 +15,7 @@ export const createComponentExample = (title: string, description: string | unde
   return { title, description, content };
 };
 
-export class ContextMenuList extends React.Component<{}> {
+export default class ContextMenuList extends React.Component<{}> {
 
   // Combines several instances of ComponentExampleProps to be passed into the ComponentContainer
   public static getContextMenuData(): ComponentExampleProps[] {

--- a/src/frontend-samples/component-gallery/context-menu-sample/sampleSpec.tsx
+++ b/src/frontend-samples/component-gallery/context-menu-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { ContextMenuList } from ".";
+import ContextMenuList from ".";
 
 // Provides the information about the sample, passing no iModels since this sample does not utilize any
 export function getContextMenuSpec(): SampleSpec {

--- a/src/frontend-samples/component-gallery/expandable-list-sample/index.tsx
+++ b/src/frontend-samples/component-gallery/expandable-list-sample/index.tsx
@@ -15,7 +15,7 @@ export const createComponentExample = (title: string, description: string | unde
   return { title, description, content };
 };
 
-export class ExpandableListList extends React.Component<{}> {
+export default class ExpandableListList extends React.Component<{}> {
 
   // Combines several instances of ComponentExampleProps to be passed into the ComponentContainer
   public static getExpandableListData(): ComponentExampleProps[] {

--- a/src/frontend-samples/component-gallery/expandable-list-sample/sampleSpec.tsx
+++ b/src/frontend-samples/component-gallery/expandable-list-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { ExpandableListList } from ".";
+import ExpandableListList from ".";
 
 // Provides the information about the sample, passing no iModels since this sample does not utilize any
 export function getExpandableListSpec(): SampleSpec {

--- a/src/frontend-samples/component-gallery/inputs-sample/index.tsx
+++ b/src/frontend-samples/component-gallery/inputs-sample/index.tsx
@@ -15,7 +15,7 @@ export const createComponentExample = (title: string, description: string | unde
   return { title, description, content };
 };
 
-export class InputsList extends React.Component<{}> {
+export default class InputsList extends React.Component<{}> {
 
   // Combines several instances of ComponentExampleProps to be passed into the ComponentContainer
   public static getInputsData(): ComponentExampleProps[] {

--- a/src/frontend-samples/component-gallery/inputs-sample/sampleSpec.tsx
+++ b/src/frontend-samples/component-gallery/inputs-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { InputsList } from ".";
+import InputsList from ".";
 
 // Provides the information about the sample, passing no iModels since this sample does not utilize any
 export function getInputsSpec(): SampleSpec {

--- a/src/frontend-samples/component-gallery/loading-sample/index.tsx
+++ b/src/frontend-samples/component-gallery/loading-sample/index.tsx
@@ -14,7 +14,7 @@ export const createComponentExample = (title: string, description: string | unde
   return { title, description, content };
 };
 
-export class LoadingList extends React.Component<{}> {
+export default class LoadingList extends React.Component<{}> {
 
   // Combines several instances of ComponentExampleProps to be passed into the ComponentContainer
   public static getLoadingData(): ComponentExampleProps[] {

--- a/src/frontend-samples/component-gallery/loading-sample/sampleSpec.tsx
+++ b/src/frontend-samples/component-gallery/loading-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { LoadingList } from ".";
+import LoadingList from ".";
 
 // Provides the information about the sample, passing no iModels since this sample does not utilize any
 export function getLoadingSpec(): SampleSpec {

--- a/src/frontend-samples/component-gallery/search-box-sample/index.tsx
+++ b/src/frontend-samples/component-gallery/search-box-sample/index.tsx
@@ -14,7 +14,7 @@ export const createComponentExample = (title: string, description: string | unde
   return { title, description, content };
 };
 
-export class SearchBoxList extends React.Component<{}> {
+export default class SearchBoxList extends React.Component<{}> {
 
   // Combines several instances of ComponentExampleProps to be passed into the ComponentContainer
   public static getSearchBoxData(): ComponentExampleProps[] {

--- a/src/frontend-samples/component-gallery/search-box-sample/sampleSpec.tsx
+++ b/src/frontend-samples/component-gallery/search-box-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { SearchBoxList } from ".";
+import SearchBoxList from ".";
 
 // Provides the information about the sample, passing no iModels since this sample does not utilize any
 export function getSearchBoxSpec(): SampleSpec {

--- a/src/frontend-samples/component-gallery/slider-sample/index.tsx
+++ b/src/frontend-samples/component-gallery/slider-sample/index.tsx
@@ -14,7 +14,7 @@ export const createComponentExample = (title: string, description: string | unde
   return { title, description, content };
 };
 
-export class SliderList extends React.Component<{}> {
+export default class SliderList extends React.Component<{}> {
 
   // Combines several instances of ComponentExampleProps to be passed into the ComponentContainer
   public static getSliderData(): ComponentExampleProps[] {

--- a/src/frontend-samples/component-gallery/slider-sample/sampleSpec.tsx
+++ b/src/frontend-samples/component-gallery/slider-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { SliderList } from ".";
+import SliderList from ".";
 
 // Provides the information about the sample, passing no iModels since this sample does not utilize any
 export function getSliderSpec(): SampleSpec {

--- a/src/frontend-samples/component-gallery/split-button-sample/index.tsx
+++ b/src/frontend-samples/component-gallery/split-button-sample/index.tsx
@@ -14,7 +14,7 @@ export const createComponentExample = (title: string, description: string | unde
   return { title, description, content };
 };
 
-export class SplitButtonList extends React.Component<{}> {
+export default class SplitButtonList extends React.Component<{}> {
 
   // Combines several instances of ComponentExampleProps to be passed into the ComponentContainer
   private static get splitButtonMenuItems(): React.ReactNode[] {

--- a/src/frontend-samples/component-gallery/split-button-sample/sampleSpec.tsx
+++ b/src/frontend-samples/component-gallery/split-button-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { SplitButtonList } from ".";
+import SplitButtonList from ".";
 
 // Provides the information about the sample, passing no iModels since this sample does not utilize any
 export function getSplitButtonSpec(): SampleSpec {

--- a/src/frontend-samples/component-gallery/tabs-sample/index.tsx
+++ b/src/frontend-samples/component-gallery/tabs-sample/index.tsx
@@ -14,7 +14,7 @@ export const createComponentExample = (title: string, description: string | unde
   return { title, description, content };
 };
 
-export class TabsList extends React.Component<{}> {
+export default class TabsList extends React.Component<{}> {
 
   // Combines several instances of ComponentExampleProps to be passed into the ComponentContainer
   public static getTabsData(): ComponentExampleProps[] {

--- a/src/frontend-samples/component-gallery/tabs-sample/sampleSpec.tsx
+++ b/src/frontend-samples/component-gallery/tabs-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { TabsList } from ".";
+import TabsList from ".";
 
 // Provides the information about the sample, passing no iModels since this sample does not utilize any
 export function getTabsSpec(): SampleSpec {

--- a/src/frontend-samples/component-gallery/text-sample/index.tsx
+++ b/src/frontend-samples/component-gallery/text-sample/index.tsx
@@ -14,7 +14,7 @@ export const createComponentExample = (title: string, description: string | unde
   return { title, description, content };
 };
 
-export class TextList extends React.Component<{}> {
+export default class TextList extends React.Component<{}> {
 
   // Combines several instances of ComponentExampleProps to be passed into the ComponentContainer
   public static getTextData(): ComponentExampleProps[] {

--- a/src/frontend-samples/component-gallery/text-sample/sampleSpec.tsx
+++ b/src/frontend-samples/component-gallery/text-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { TextList } from ".";
+import TextList from ".";
 
 // Provides the information about the sample, passing no iModels since this sample does not utilize any
 export function getTextSpec(): SampleSpec {

--- a/src/frontend-samples/component-gallery/tiles-sample/index.tsx
+++ b/src/frontend-samples/component-gallery/tiles-sample/index.tsx
@@ -14,7 +14,7 @@ export const createComponentExample = (title: string, description: string | unde
   return { title, description, content };
 };
 
-export class TilesList extends React.Component<{}> {
+export default class TilesList extends React.Component<{}> {
 
   // Combines several instances of ComponentExampleProps to be passed into the ComponentContainer
   public static getTilesData(): ComponentExampleProps[] {

--- a/src/frontend-samples/component-gallery/tiles-sample/sampleSpec.tsx
+++ b/src/frontend-samples/component-gallery/tiles-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { TilesList } from ".";
+import TilesList from ".";
 
 // Provides the information about the sample, passing no iModels since this sample does not utilize any
 export function getTilesSpec(): SampleSpec {

--- a/src/frontend-samples/component-gallery/toggle-sample/index.tsx
+++ b/src/frontend-samples/component-gallery/toggle-sample/index.tsx
@@ -14,7 +14,7 @@ export const createComponentExample = (title: string, description: string | unde
   return { title, description, content };
 };
 
-export class ToggleList extends React.Component<{}> {
+export default class ToggleList extends React.Component<{}> {
 
   // Combines several instances of ComponentExampleProps to be passed into the ComponentContainer
   public static getToggleData(): ComponentExampleProps[] {

--- a/src/frontend-samples/component-gallery/toggle-sample/sampleSpec.tsx
+++ b/src/frontend-samples/component-gallery/toggle-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { ToggleList } from ".";
+import ToggleList from ".";
 
 // Provides the information about the sample, passing no iModels since this sample does not utilize any
 export function getToggleSpec(): SampleSpec {

--- a/src/frontend-samples/emphasize-elements-sample/index.tsx
+++ b/src/frontend-samples/emphasize-elements-sample/index.tsx
@@ -12,7 +12,7 @@ import { ColorPickerButton } from "@bentley/ui-components";
 import { ColorDef } from "@bentley/imodeljs-common";
 import { ReloadableViewport } from "../../Components/Viewport/ReloadableViewport";
 
-export class EmphasizeElementsApp {
+export default class EmphasizeElementsApp {
   public static async setup(iModelName: string, iModelSelector: React.ReactNode) {
     return <EmphasizeElementsUI iModelName={iModelName} iModelSelector={iModelSelector} />;
   }

--- a/src/frontend-samples/emphasize-elements-sample/sampleSpec.tsx
+++ b/src/frontend-samples/emphasize-elements-sample/sampleSpec.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../Components/SampleShowcase/SampleShowcase";
 import { SampleIModels } from "../../Components/IModelSelector/IModelSelector";
-import { EmphasizeElementsApp } from ".";
+import EmphasizeElementsApp from ".";
 
 export function getEmphasizeElementsSpec(): SampleSpec {
   return ({

--- a/src/frontend-samples/heatmap-decorator-sample/index.tsx
+++ b/src/frontend-samples/heatmap-decorator-sample/index.tsx
@@ -22,7 +22,7 @@ NEEDSWORK: split into three files
 */
 
 /** This class implements the interaction between the sample and the iModel.js API.  No user interface. */
-export class HeatmapDecoratorApp {
+export default class HeatmapDecoratorApp {
 
   public static decorator?: HeatmapDecorator;
   public static range?: Range2d;

--- a/src/frontend-samples/heatmap-decorator-sample/sampleSpec.tsx
+++ b/src/frontend-samples/heatmap-decorator-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../Components/SampleShowcase/SampleShowcase";
-import { HeatmapDecoratorApp } from ".";
+import HeatmapDecoratorApp from ".";
 
 export function getHeatmapDecoratorSpec(): SampleSpec {
   return ({

--- a/src/frontend-samples/marker-pin-sample/index.tsx
+++ b/src/frontend-samples/marker-pin-sample/index.tsx
@@ -22,7 +22,7 @@ interface ManualPinSelection {
   image: string;
 }
 
-export class MarkerPinsApp {
+export default class MarkerPinsApp {
   private static _sampleNamespace: I18NNamespace;
   private static _markerDecorator?: MarkerPinDecorator;
   public static range?: Range2d;

--- a/src/frontend-samples/marker-pin-sample/sampleSpec.tsx
+++ b/src/frontend-samples/marker-pin-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../Components/SampleShowcase/SampleShowcase";
-import { MarkerPinsApp } from ".";
+import MarkerPinsApp from ".";
 
 export function getMarkerPinSpec(): SampleSpec {
   return ({

--- a/src/frontend-samples/shadow-study-sample/index.tsx
+++ b/src/frontend-samples/shadow-study-sample/index.tsx
@@ -9,7 +9,7 @@ import { IModelApp, IModelConnection, ViewState } from "@bentley/imodeljs-fronte
 import { ReloadableViewport } from "../../Components/Viewport/ReloadableViewport";
 import { ViewSetup } from "../../api/viewSetup";
 
-export class ShadowStudyApp {
+export default class ShadowStudyApp {
 
   public static async setup(iModelName: string, iModelSelector: React.ReactNode) {
     return <ShadowStudyUI iModelName={iModelName} iModelSelector={iModelSelector} />;

--- a/src/frontend-samples/shadow-study-sample/sampleSpec.tsx
+++ b/src/frontend-samples/shadow-study-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../Components/SampleShowcase/SampleShowcase";
-import { ShadowStudyApp } from ".";
+import ShadowStudyApp from ".";
 
 export function getShadowStudySpec(): SampleSpec {
   return ({

--- a/src/frontend-samples/thematic-display-sample/index.tsx
+++ b/src/frontend-samples/thematic-display-sample/index.tsx
@@ -77,7 +77,7 @@ class API {
 }
 
 /** Handles the setup and teardown of the thematic display sample */
-export class ThematicDisplaySampleApp {
+export default class ThematicDisplaySampleApp {
   public static originalProps?: ThematicDisplayProps;
   public static originalFlag: boolean = false;
   public static viewport?: Viewport;

--- a/src/frontend-samples/thematic-display-sample/sampleSpec.tsx
+++ b/src/frontend-samples/thematic-display-sample/sampleSpec.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../Components/SampleShowcase/SampleShowcase";
 import { SampleIModels } from "../../Components/IModelSelector/IModelSelector";
-import { ThematicDisplaySampleApp } from ".";
+import ThematicDisplaySampleApp from ".";
 
 export function getThematicDisplaySpec(): SampleSpec {
   return ({

--- a/src/frontend-samples/tooltip-customize-sample/index.tsx
+++ b/src/frontend-samples/tooltip-customize-sample/index.tsx
@@ -25,7 +25,7 @@ interface TooltipCustomizeSettings {
   elemProperty: ElemProperty;
 }
 
-export class TooltipCustomizeApp {
+export default class TooltipCustomizeApp {
   public static settings: TooltipCustomizeSettings = {
     showImage: true,
     showCustomText: false,

--- a/src/frontend-samples/tooltip-customize-sample/sampleSpec.tsx
+++ b/src/frontend-samples/tooltip-customize-sample/sampleSpec.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../Components/SampleShowcase/SampleShowcase";
-import { TooltipCustomizeApp } from ".";
+import TooltipCustomizeApp from ".";
 
 export function getTooltipCustomizeSpec(): SampleSpec {
   return ({

--- a/src/frontend-samples/tree-samples/basic-tree/index.tsx
+++ b/src/frontend-samples/tree-samples/basic-tree/index.tsx
@@ -8,7 +8,7 @@ import "../index.scss";
 import { ControlledTree, SelectionMode, useTreeEventsHandler, useTreeModelSource, useTreeNodeLoader, useVisibleTreeNodes } from "@bentley/ui-components";
 import { SampleDataProvider } from "../Common";
 
-export class BasicTreeSample extends React.Component<{}> {
+export default class BasicTreeSample extends React.Component<{}> {
 
   public getControlPane() {
     return (

--- a/src/frontend-samples/tree-samples/basic-tree/sampleSpec.tsx
+++ b/src/frontend-samples/tree-samples/basic-tree/sampleSpec.tsx
@@ -1,6 +1,6 @@
 
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { BasicTreeSample } from ".";
+import BasicTreeSample from ".";
 
 export function getBasicTreeSpec(): SampleSpec {
   return ({

--- a/src/frontend-samples/tree-samples/custom-checkboxes-tree/index.tsx
+++ b/src/frontend-samples/tree-samples/custom-checkboxes-tree/index.tsx
@@ -14,7 +14,7 @@ import { SampleDataProvider } from "../Common";
 
 import { ImageCheckBox, NodeCheckboxRenderProps } from "@bentley/ui-core";
 
-export class CustomCheckboxesTreeSample extends React.Component<{}> {
+export default class CustomCheckboxesTreeSample extends React.Component<{}> {
 
   public getControlPane() {
     return (

--- a/src/frontend-samples/tree-samples/custom-checkboxes-tree/sampleSpec.tsx
+++ b/src/frontend-samples/tree-samples/custom-checkboxes-tree/sampleSpec.tsx
@@ -1,5 +1,5 @@
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { CustomCheckboxesTreeSample } from ".";
+import CustomCheckboxesTreeSample from ".";
 
 export function getCustomCheckboxesTreeSpec(): SampleSpec {
   return ({

--- a/src/frontend-samples/tree-samples/custom-event-handler-tree/index.tsx
+++ b/src/frontend-samples/tree-samples/custom-event-handler-tree/index.tsx
@@ -15,7 +15,7 @@ import { CheckBoxState, useDisposable } from "@bentley/ui-core";
 
 import { SampleDataProvider } from "../Common";
 
-export class CustomEventHandlerTreeSample extends React.Component<{}> {
+export default class CustomEventHandlerTreeSample extends React.Component<{}> {
 
   public getControlPane() {
     return (

--- a/src/frontend-samples/tree-samples/custom-event-handler-tree/sampleSpec.tsx
+++ b/src/frontend-samples/tree-samples/custom-event-handler-tree/sampleSpec.tsx
@@ -1,5 +1,5 @@
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { CustomEventHandlerTreeSample } from ".";
+import CustomEventHandlerTreeSample from ".";
 
 export function getCustomEventHandlerTreeSpec(): SampleSpec {
   return ({

--- a/src/frontend-samples/tree-samples/custom-table-node-tree/index.tsx
+++ b/src/frontend-samples/tree-samples/custom-table-node-tree/index.tsx
@@ -15,7 +15,7 @@ import { PropertyRecord } from "@bentley/ui-abstract";
 import { BeEvent } from "@bentley/bentleyjs-core";
 import "./TableNodeTree.scss";
 
-export class TableNodeTreeSample extends React.Component<{}> {
+export default class TableNodeTreeSample extends React.Component<{}> {
 
   public getControlPane() {
     return (

--- a/src/frontend-samples/tree-samples/custom-table-node-tree/sampleSpec.tsx
+++ b/src/frontend-samples/tree-samples/custom-table-node-tree/sampleSpec.tsx
@@ -1,5 +1,5 @@
 import { SampleSpec } from "../../../Components/SampleShowcase/SampleShowcase";
-import { TableNodeTreeSample } from ".";
+import TableNodeTreeSample from ".";
 
 export function getCustomTableNodeTreeSpec(): SampleSpec {
   return ({

--- a/src/frontend-samples/view-attributes-sample/index.tsx
+++ b/src/frontend-samples/view-attributes-sample/index.tsx
@@ -145,7 +145,7 @@ interface ViewAttributesState {
 }
 
 /** A React component that renders the UI specific for this sample */
-export class ViewAttributesUI extends React.Component<{ iModelName: string, iModelSelector: React.ReactNode }, ViewAttributesState> {
+export default class ViewAttributesUI extends React.Component<{ iModelName: string, iModelSelector: React.ReactNode }, ViewAttributesState> {
 
   /** Creates a Sample instance */
   constructor(props?: any, context?: any) {

--- a/src/frontend-samples/view-attributes-sample/sampleSpec.tsx
+++ b/src/frontend-samples/view-attributes-sample/sampleSpec.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../Components/SampleShowcase/SampleShowcase";
 import React from "react";
-import { ViewAttributesUI } from ".";
+import ViewAttributesUI from ".";
 
 export function getViewAttributesSpec(): SampleSpec {
   return ({

--- a/src/frontend-samples/view-clip-sample/index.tsx
+++ b/src/frontend-samples/view-clip-sample/index.tsx
@@ -23,7 +23,7 @@ interface ViewClipUIState {
 }
 
 /** A React component that renders the UI specific for this sample */
-export class ViewClipUI extends React.Component<ViewClipUIProps, ViewClipUIState> {
+export default class ViewClipUI extends React.Component<ViewClipUIProps, ViewClipUIState> {
   /** Creates an Sample instance */
   constructor(props?: any, context?: any) {
     super(props, context);

--- a/src/frontend-samples/view-clip-sample/sampleSpec.tsx
+++ b/src/frontend-samples/view-clip-sample/sampleSpec.tsx
@@ -5,7 +5,7 @@
 import * as React from "react";
 import { SampleSpec } from "../../Components/SampleShowcase/SampleShowcase";
 import { SampleIModels } from "../../Components/IModelSelector/IModelSelector";
-import { ViewClipUI } from ".";
+import ViewClipUI from ".";
 
 export function getViewClipSpec(): SampleSpec {
   return ({

--- a/src/frontend-samples/viewer-only-2d-sample/index.tsx
+++ b/src/frontend-samples/viewer-only-2d-sample/index.tsx
@@ -22,7 +22,7 @@ interface ViewerOnly2dState {
 }
 
 /** A React component that renders the UI specific for this sample */
-export class ViewerOnly2dUI extends React.Component<ViewerOnly2dProps, ViewerOnly2dState> {
+export default class ViewerOnly2dUI extends React.Component<ViewerOnly2dProps, ViewerOnly2dState> {
 
   /** Creates a Sample instance */
   constructor(props?: any, context?: any) {

--- a/src/frontend-samples/viewer-only-2d-sample/sampleSpec.tsx
+++ b/src/frontend-samples/viewer-only-2d-sample/sampleSpec.tsx
@@ -4,8 +4,9 @@
 *--------------------------------------------------------------------------------------------*/
 import { SampleSpec } from "../../Components/SampleShowcase/SampleShowcase";
 import React from "react";
-import { ViewerOnly2dUI } from ".";
+
 import { SampleIModels } from "../../Components/IModelSelector/IModelSelector";
+import ViewerOnly2dUI from ".";
 
 export function getViewerOnly2dSpec(): SampleSpec {
   return ({

--- a/src/frontend-samples/viewport-only-sample/index.tsx
+++ b/src/frontend-samples/viewport-only-sample/index.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import { ReloadableViewport } from "../../Components/Viewport/ReloadableViewport";
 import "../../common/samples-common.scss";
 
-export class ViewportOnlyUI extends React.Component<{ iModelName: string, iModelSelector: React.ReactNode }, {}> {
+export default class ViewportOnlyUI extends React.Component<{ iModelName: string, iModelSelector: React.ReactNode }, {}> {
 
   /** The sample's render method */
   public render() {

--- a/src/frontend-samples/viewport-only-sample/sampleSpec.tsx
+++ b/src/frontend-samples/viewport-only-sample/sampleSpec.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import React from "react";
 import { SampleSpec } from "../../Components/SampleShowcase/SampleShowcase";
-import { ViewportOnlyUI } from ".";
+import ViewportOnlyUI from ".";
 
 export function getViewportOnlySpec(): SampleSpec {
   return ({

--- a/src/frontend-samples/zoom-to-elements-sample/index.tsx
+++ b/src/frontend-samples/zoom-to-elements-sample/index.tsx
@@ -45,7 +45,7 @@ interface ZoomToState {
 }
 
 /** A React component that renders the UI specific for this sample */
-export class ZoomToElementsUI extends React.Component<ZoomToProps, ZoomToState> {
+export default class ZoomToElementsUI extends React.Component<ZoomToProps, ZoomToState> {
   private _ignoreSelectionChanged = false;
   private _listRef = React.createRef<HTMLSelectElement>();
 

--- a/src/frontend-samples/zoom-to-elements-sample/sampleSpec.tsx
+++ b/src/frontend-samples/zoom-to-elements-sample/sampleSpec.tsx
@@ -5,7 +5,7 @@
 import React from "react";
 import { SampleSpec } from "../../Components/SampleShowcase/SampleShowcase";
 import { SampleIModels } from "../../Components/IModelSelector/IModelSelector";
-import { ZoomToElementsUI } from ".";
+import ZoomToElementsUI from ".";
 
 export function getZoomToElementsSpec(): SampleSpec {
   return ({


### PR DESCRIPTION
Pre-Monaco-Editor upgrade for code editing and running. Code editor requires the modules that will be run to be default exports. All samples are now exported as defaults.