### PR TITLE
Fix sheet border size

### DIFF
--- a/src/frontend-samples/viewer-only-2d-sample/ViewCreator2d.ts
+++ b/src/frontend-samples/viewer-only-2d-sample/ViewCreator2d.ts
@@ -118,15 +118,19 @@ export class ViewCreator2d {
   }
 
   private async _addSheetViewProps(modelId: Id64String, props: ViewStateProps) {
-
-    const modelRange: any = (await this._imodel.models.queryModelRanges(modelId))[0];
-
+    let width = 0;
+    let height = 0;
+    for await (const row of this._imodel.query(`SELECT Width, Height FROM bis.Sheet WHERE ECInstanceId = ${modelId}`)) {
+      width = row.width as number;
+      height = row.height as number;
+      break;
+    }
     const sheetProps: SheetProps = {
       model: modelId,
       code: { spec: "", scope: "" },
       classFullName: "DrawingSheetModel",
-      height: modelRange.high[1] - modelRange.low[1],
-      width: modelRange.high[0] - modelRange.low[0],
+      height,
+      width,
     };
 
     props.sheetAttachments = await this._getSheetAttachments(modelId);


### PR DESCRIPTION
ViewCreator2d was mistakenly assuming that the sheet size is the same as the sheet model's range. The model range is the union of all of its elements ranges. The sheet size is typically larger than that so that it can encompass the contents with a margin (but can also be smaller because sometimes people draw outside the border).

Fix: Query the iModel for the actual sheet size instead.