### PR TITLE
Add feature flags to sample showcase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11045,6 +11045,25 @@
         "webpack-sources": "^1.1.0"
       }
     },
+    "launchdarkly-js-client-sdk": {
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-2.17.5.tgz",
+      "integrity": "sha512-ca6Dud0uD63GOh3ghIFzWi9IkRtAKsI29GWJNvL6TSrWH0Ez/IddAu6GqVK/6SSPOpNCOl+LjVxFIYtoDv4pLA==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "launchdarkly-js-sdk-common": "3.2.8"
+      }
+    },
+    "launchdarkly-js-sdk-common": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-3.2.8.tgz",
+      "integrity": "sha512-inZVhqRPJcs9jIOeEHFb5LmNbemWMRx2jJY0VIQajKAaDymseGxx2XVfeZukTrNKyB5JBNVMYpTRvnawWuLJQw==",
+      "requires": {
+        "base64-js": "^1.3.0",
+        "fast-deep-equal": "^2.0.1",
+        "uuid": "^3.3.2"
+      }
+    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
+    "launchdarkly-js-client-sdk": "^2.17.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "tooltip.js": "^1.2.0",

--- a/src/Components/SampleEditor/SampleEditor.tsx
+++ b/src/Components/SampleEditor/SampleEditor.tsx
@@ -60,6 +60,8 @@ export default class SampleEditor extends React.Component<SampleEditorProps, Sam
 
   public render() {
     let problemCount = 0;
+    const urlEnableEditor = new URLSearchParams(window.location.search).get("editor");
+    const executable = urlEnableEditor ? urlEnableEditor.toLowerCase() === "true" : FeatureToggleClient.isFeatureEnabled(featureFlags.enableEditor);
     this.state.diagnostics &&
       this.state.diagnostics.forEach(
         (diagnostic) =>
@@ -74,7 +76,7 @@ export default class SampleEditor extends React.Component<SampleEditorProps, Sam
         <MonacoEditor
           enableExplorer={false}
           enableTabNavigation={true}
-          enableTranspiler={FeatureToggleClient.isFeatureEnabled(featureFlags.enableEditor)}
+          enableTranspiler={executable}
           modules={modules as Module[]}
           files={this.props.files}
           onTranspiled={this.props.onTranspiled}

--- a/src/Components/SampleEditor/SampleEditor.tsx
+++ b/src/Components/SampleEditor/SampleEditor.tsx
@@ -7,6 +7,7 @@ import "@bentley/monaco-editor/lib/editor/icons/codicon.css";
 import * as React from "react";
 import { modules } from "./Modules";
 import "./SampleEditor.scss";
+import { FeatureToggleClient, featureFlags } from "../../FeatureToggleClient";
 
 export interface SampleEditorProps {
   files?: any[];
@@ -29,6 +30,7 @@ export default class SampleEditor extends React.Component<SampleEditorProps, Sam
   }
 
   public componentDidUpdate(prevProps: SampleEditorProps) {
+
     if (this.props.files !== prevProps.files) {
       this.setState({ diagnostics: [] });
     }
@@ -66,12 +68,13 @@ export default class SampleEditor extends React.Component<SampleEditorProps, Sam
             (diagnostic.suggestionDiagnostics?.length || 0) +
             (diagnostic.syntacticDiagnostics?.length || 0)),
       );
+
     return (
       <SplitScreen split={"horizontal"} size={this.state.active ? 201 : 35} minSize={35} className="sample-editor" primary="second" pane2Style={this.state.active ? undefined : { height: "35px" }} onChange={this._onSplitChange} allowResize={!!this.state.active}>
         <MonacoEditor
           enableExplorer={false}
           enableTabNavigation={true}
-          enableTranspiler={true}
+          enableTranspiler={FeatureToggleClient.isFeatureEnabled(featureFlags.enableEditor)}
           modules={modules as Module[]}
           files={this.props.files}
           onTranspiled={this.props.onTranspiled}

--- a/src/Components/SampleEditor/SampleEditor.tsx
+++ b/src/Components/SampleEditor/SampleEditor.tsx
@@ -7,7 +7,7 @@ import "@bentley/monaco-editor/lib/editor/icons/codicon.css";
 import * as React from "react";
 import { modules } from "./Modules";
 import "./SampleEditor.scss";
-import { FeatureToggleClient, featureFlags } from "../../FeatureToggleClient";
+import { featureFlags, FeatureToggleClient } from "../../FeatureToggleClient";
 
 export interface SampleEditorProps {
   files?: any[];

--- a/src/Components/SampleShowcase/SampleShowcase.tsx
+++ b/src/Components/SampleShowcase/SampleShowcase.tsx
@@ -133,6 +133,11 @@ export class SampleShowcase extends React.Component<{}, ShowcaseState> {
       params.append("group", groupName);
       params.append("sample", sampleName);
 
+      // Detect if editor was enabled in URL params as a semi-backdoor, this
+      // bypasses the ld feature flag
+      const editorEnabled = new URLSearchParams(window.location.search).get("editor");
+      if (editorEnabled) params.append("editor", editorEnabled);
+
       window.history.replaceState(null, "", "?" + params.toString());
     });
   }

--- a/src/FeatureToggleClient.ts
+++ b/src/FeatureToggleClient.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { LDClient, LDFlagValue, initialize } from "launchdarkly-js-client-sdk";
+import { Guid, assert } from "@bentley/bentleyjs-core";
+
+/** Lists all feature flags used including the LaunchDarkly key name.
+ *  This simplifies maintenance consistency between flags defined in LaunchDarkly
+ *  and used by the sample showcase.
+ */
+export const featureFlags = {
+  enableEditor: "sample-showcase-code-editor",
+};
+
+export class FeatureToggleClient {
+  private static readonly _ldClientSideIds: { [deploymentEnv: string]: string } = {
+    DEPLOYED: "5beb1872d4851c306086a4fc"
+  };
+
+  private static _ldClient?: LDClient;
+  private static _offlineValue: boolean = false;
+
+  public static isFeatureEnabled(featureKey: string, defaultValue?: boolean): boolean {
+    if (!FeatureToggleClient._ldClient)
+      return false;
+
+    return FeatureToggleClient.evaluateFeature(featureKey, !!defaultValue ? defaultValue : FeatureToggleClient._offlineValue) as boolean;
+  }
+
+  public static async initialize(): Promise<void> {
+    assert(!FeatureToggleClient._ldClient, "FeatureToggleClient.initialize must not be called twice.");
+    const ldClient: LDClient = initialize(FeatureToggleClient._ldClientSideIds.DEPLOYED, { key: Guid.createValue(), anonymous: true }, { evaluationReasons: false, streaming: false, sendLDHeaders: false });
+    await ldClient.waitUntilReady();
+    FeatureToggleClient._ldClient = ldClient;
+  }
+
+  private static evaluateFeature(featureKey: string, defaultValue?: LDFlagValue): LDFlagValue {
+    assert(!!FeatureToggleClient._ldClient, "FeatureToggleClient.initialize hasn't been called yet.");
+    return FeatureToggleClient._ldClient!.variation(featureKey, defaultValue);
+
+  }
+}

--- a/src/FeatureToggleClient.ts
+++ b/src/FeatureToggleClient.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { LDClient, LDFlagValue, initialize } from "launchdarkly-js-client-sdk";
+import { initialize, LDClient, LDFlagValue } from "launchdarkly-js-client-sdk";
 import { Guid, assert } from "@bentley/bentleyjs-core";
 
 /** Lists all feature flags used including the LaunchDarkly key name.
@@ -16,7 +16,7 @@ export const featureFlags = {
 
 export class FeatureToggleClient {
   private static readonly _ldClientSideIds: { [deploymentEnv: string]: string } = {
-    DEPLOYED: "5beb1872d4851c306086a4fc"
+    DEPLOYED: "5beb1872d4851c306086a4fc",
   };
 
   private static _ldClient?: LDClient;

--- a/src/FeatureToggleClient.ts
+++ b/src/FeatureToggleClient.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { initialize, LDClient, LDFlagValue } from "launchdarkly-js-client-sdk";
-import { Guid, assert } from "@bentley/bentleyjs-core";
+import { assert, Guid } from "@bentley/bentleyjs-core";
 
 /** Lists all feature flags used including the LaunchDarkly key name.
  *  This simplifies maintenance consistency between flags defined in LaunchDarkly

--- a/src/SampleBaseApp.ts
+++ b/src/SampleBaseApp.ts
@@ -13,6 +13,7 @@ import { UiComponents } from "@bentley/ui-components";
 import { ShowcaseToolAdmin } from "./api/showcasetooladmin";
 import { ShowcaseNotificationManager } from "./api/Notifications/NotificationManager";
 import { NoSignInIAuthClient } from "./NoSignInIAuthClient";
+import { FeatureToggleClient } from "./FeatureToggleClient";
 
 // Boiler plate code
 export interface SampleContext {
@@ -92,6 +93,8 @@ export class SampleBaseApp {
     const userURL = Config.App.get("imjs_sample_showcase_user", "https://prod-imodeldeveloperservices-eus.azurewebsites.net/api/v0/sampleShowcaseUser");
     await authClient.generateTokenString(userURL, new ClientRequestContext());
     IModelApp.authorizationClient = authClient;
+
+    await FeatureToggleClient.initialize();
 
     try {
       await SampleBaseApp.oidcClient.signInSilent(new ClientRequestContext());


### PR DESCRIPTION
This PR adds launch darkly feature flags to the sample showcase.

The first feature flag is to enable/disable the editor in the sample.