### PR TITLE
Add copyright headers to ErrorBoundary.tsx and ErrorDisplay.scss.

### DIFF
--- a/src/Components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/Components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,3 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import { DisplayError } from "./ErrorDisplay";
 

--- a/src/Components/ErrorBoundary/ErrorDisplay.scss
+++ b/src/Components/ErrorBoundary/ErrorDisplay.scss
@@ -1,3 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
 #error-overlay {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Our validate sources build step is failing because of these two files.