### PR TITLE
Fix bug for heatmaps and marker pins when imodel changes.

### DIFF
--- a/src/frontend-samples/heatmap-decorator-sample/HeatmapDecoratorApp.tsx
+++ b/src/frontend-samples/heatmap-decorator-sample/HeatmapDecoratorApp.tsx
@@ -13,10 +13,7 @@ import SampleApp from "common/SampleApp";
 
 /** This class implements the interaction between the sample and the iModel.js API.  No user interface. */
 export default class HeatmapDecoratorApp implements SampleApp {
-
   public static decorator?: HeatmapDecorator;
-  public static range?: Range2d;
-  public static height?: number;
 
   public static async setup(iModelName: string, setupControlPane: (instructions: string, controls?: React.ReactNode) => void): Promise<React.ReactNode> {
     return <HeatmapDecoratorUI iModelName={iModelName} setupControlPane={setupControlPane} />;
@@ -27,9 +24,8 @@ export default class HeatmapDecoratorApp implements SampleApp {
     HeatmapDecoratorApp.decorator = undefined;
   }
 
-  public static setupDecorator(points: Point3d[], spreadFactor: number) {
-    HeatmapDecoratorApp.decorator = new HeatmapDecorator(points, this.range!, spreadFactor, this.height!);
-    HeatmapDecoratorApp.enableDecorations();
+  public static setupDecorator(points: Point3d[], range: Range2d, spreadFactor: number, height: number) {
+    HeatmapDecoratorApp.decorator = new HeatmapDecorator(points, range, spreadFactor, height);
   }
 
   public static enableDecorations() {

--- a/src/frontend-samples/heatmap-decorator-sample/HeatmapDecoratorUI.tsx
+++ b/src/frontend-samples/heatmap-decorator-sample/HeatmapDecoratorUI.tsx
@@ -25,6 +25,9 @@ interface HeatmapDecoratorUIState {
   vp?: Viewport;
   showDecorator: boolean;
   spreadFactor: number;
+  points: Point3d[];
+  range: Range2d;
+  height: number;
 }
 
 /** A React component that renders the UI specific for this sample */
@@ -35,21 +38,22 @@ export default class HeatmapDecoratorUI extends React.Component<HeatmapDecorator
     this.state = {
       showDecorator: true,
       spreadFactor: 10,
+      points: [],
+      range: Range2d.createNull(),
+      height: 0,
     };
   }
 
   private _onPointsChanged = (points: Point3d[]) => {
-    if (undefined === HeatmapDecoratorApp.decorator) {
-      HeatmapDecoratorApp.setupDecorator(points, this.state.spreadFactor);
-      return;
-    }
-
-    HeatmapDecoratorApp.decorator.setPoints(points);
+    this.setState({ points }, () => {
+      if (HeatmapDecoratorApp.decorator)
+        HeatmapDecoratorApp.decorator.setPoints(this.state.points);
+    });
   }
 
   private _onChangeSpreadFactor = (event: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({ spreadFactor: Number(event.target.value) }, () => {
-      if (undefined !== HeatmapDecoratorApp.decorator)
+      if (HeatmapDecoratorApp.decorator)
         HeatmapDecoratorApp.decorator.setSpreadFactor(this.state.spreadFactor);
     });
   }
@@ -89,13 +93,18 @@ export default class HeatmapDecoratorUI extends React.Component<HeatmapDecorator
     IModelApp.viewManager.onViewOpen.addOnce((vp: ScreenViewport) => {
 
       // Grab range of the contents of the view. We'll use this to size the heatmap.
-      const range = vp.view.computeFitRange();
-      HeatmapDecoratorApp.range = Range2d.createFrom(range);
+      const range3d = vp.view.computeFitRange();
+      const range = Range2d.createFrom(range3d);
 
       // We'll draw the heatmap as an overlay in the center of the view's Z extents.
-      HeatmapDecoratorApp.height = range.high.interpolate(0.5, range.low).z;
+      const height = range3d.high.interpolate(0.5, range3d.low).z;
 
-      this.setState({ imodel, vp });
+      this.setState({ imodel, vp, range, height }, () => {
+        if (this.state.showDecorator) {
+          HeatmapDecoratorApp.setupDecorator(this.state.points, this.state.range, this.state.spreadFactor, this.state.height);
+          HeatmapDecoratorApp.enableDecorations();
+        }
+      });
     });
   }
 
@@ -106,7 +115,7 @@ export default class HeatmapDecoratorUI extends React.Component<HeatmapDecorator
         <div className="sample-options-2col">
           <span>Show Heatmap</span>
           <Toggle isOn={this.state.showDecorator} onChange={this._onChangeShowHeatmap} />
-          <PointSelector onPointsChanged={this._onPointsChanged} range={HeatmapDecoratorApp.range} />
+          <PointSelector onPointsChanged={this._onPointsChanged} range={this.state.range} />
           <span>Spread Factor</span>
           <input type="range" min="1" max="100" value={this.state.spreadFactor} onChange={this._onChangeSpreadFactor}></input>
         </div>

--- a/src/frontend-samples/marker-pin-sample/MarkerPinApp.tsx
+++ b/src/frontend-samples/marker-pin-sample/MarkerPinApp.tsx
@@ -5,7 +5,7 @@
 import * as React from "react";
 import "@bentley/icons-generic-webfont/dist/bentley-icons-generic-webfont.css";
 import "common/samples-common.scss";
-import { Point3d, Range2d } from "@bentley/geometry-core";
+import { Point3d } from "@bentley/geometry-core";
 import { imageElementFromUrl, IModelApp } from "@bentley/imodeljs-frontend";
 import { I18NNamespace } from "@bentley/imodeljs-i18n";
 import { MarkerPinDecorator } from "./MarkerPinDecorator";
@@ -16,8 +16,6 @@ import SampleApp from "common/SampleApp";
 export default class MarkerPinApp implements SampleApp {
   private static _sampleNamespace: I18NNamespace;
   private static _markerDecorator?: MarkerPinDecorator;
-  public static range?: Range2d;
-  public static height?: number;
   public static _images: Map<string, HTMLImageElement>;
 
   public static async setup(iModelName: string, setupControlPane: (instructions: string, controls?: React.ReactNode) => void): Promise<React.ReactNode> {
@@ -52,18 +50,16 @@ export default class MarkerPinApp implements SampleApp {
       return;
 
     this._markerDecorator = new MarkerPinDecorator();
-
     this.setMarkerPoints(points);
-    this.enableDecorations();
   }
 
   public static setMarkerPoints(points: Point3d[]) {
-    if (null != this._markerDecorator)
+    if (this._markerDecorator)
       this._markerDecorator.setPoints(points, this._images.get("Google_Maps_pin.svg")!);
   }
 
   public static addMarkerPoint(point: Point3d, pinImage: HTMLImageElement) {
-    if (null != this._markerDecorator)
+    if (this._markerDecorator)
       this._markerDecorator.addPoint(point, pinImage);
   }
 


### PR DESCRIPTION
Move points, range, and height into UI state for both heatmap and marker pins.  When a new iModel is selected update the range and height.  The PointSelector control will automatically regenerate the points when it gets the new range.