### PR TITLE
Revert object-path to use upgraded 0.11.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5937,7 +5937,7 @@
         "assert": "1.4.1",
         "camelcase": "5.0.0",
         "loader-utils": "1.2.3",
-        "object-path": "0.11.4",
+        "object-path": "0.11.5",
         "regex-parser": "2.2.10"
       },
       "dependencies": {
@@ -5970,8 +5970,8 @@
           }
         },
         "object-path": {
-          "version": "0.11.4",
-          "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
+          "version": "0.11.5",
+          "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.5.tgz",
           "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5972,7 +5972,7 @@
         "object-path": {
           "version": "0.11.5",
           "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.5.tgz",
-          "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
+          "integrity": "sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg=="
         }
       }
     },


### PR DESCRIPTION
We need to upgrade @bentley/react-scripts to >=3.4.6. 

There is a dependency (object-path) that is causing audit issues. Every time a new package is introduced, the merge will revert package-lock.json and cause another audit failure.

This PR temporarily fixes the issue to push the latest changes.