### PR TITLE
Fixed Regression

### DIFF
--- a/src/Components/GenericReloadableComponent/GenericReloadableComponent.tsx
+++ b/src/Components/GenericReloadableComponent/GenericReloadableComponent.tsx
@@ -39,15 +39,13 @@ export class ReloadableConnection extends React.PureComponent<ReloadableConnecti
     );
   }
 
-  public static getDerivedStateFromProps(props: ReloadableConnectionProps, state: ReloadableConnectionState) {
-    if (state.imodel && props.iModelName !== state.imodel.name) {
-      return ({ ...state, imodel: undefined, viewState: undefined });
+  public componentDidUpdate(_prevProps: ReloadableConnectionProps, prevState: ReloadableConnectionState) {
+
+    if (this.state.imodel && _prevProps.iModelName !== this.props.iModelName) {
+      this.setState({ imodel: undefined });
+      return;
     }
 
-    return null;
-  }
-
-  public componentDidUpdate(_prevProps: ReloadableConnectionProps, prevState: ReloadableConnectionState) {
     if (this.state.imodel && prevState.imodel !== this.state.imodel) {
       if (this.props.onIModelReady)
         this.props.onIModelReady(this.state.imodel);


### PR DESCRIPTION
The issue was caused by the old way I was checking if the model had changed. I was comparing the name passed in from the selector to the name of the imodel connection. It seems like the naming convention on the imodel connection changed, which would always make the reloadable component think that the imodel had just changed, so it would never provide the imodel connection to the tree samples. Now, the reloadable component compares the old imodel name property to the new imodel name property, which will prevent this issue from occurring again.