### PR TITLE
Marker pin bugfix

### DIFF
--- a/src/frontend-samples/marker-pin-sample/MarkerPinUI.tsx
+++ b/src/frontend-samples/marker-pin-sample/MarkerPinUI.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import "@bentley/icons-generic-webfont/dist/bentley-icons-generic-webfont.css";
 import "common/samples-common.scss";
 import { Point3d, Range2d } from "@bentley/geometry-core";
-import { IModelApp, IModelConnection, ScreenViewport, StandardViewId, ViewState } from "@bentley/imodeljs-frontend";
+import { IModelApp, IModelConnection, ScreenViewport, StandardViewId, Viewport, ViewState } from "@bentley/imodeljs-frontend";
 import { Button, ButtonType, Toggle } from "@bentley/ui-core";
 import { PlaceMarkerTool } from "./PlaceMarkerTool";
 import { PopupMenu } from "./PopupMenu";
@@ -24,6 +24,7 @@ interface ManualPinSelection {
 
 interface MarkerPinsUIState {
   imodel?: IModelConnection;
+  viewport?: ScreenViewport;
   showDecorator: boolean;
   manualPin: ManualPinSelection;
   points: Point3d[];
@@ -135,16 +136,16 @@ export default class MarkerPinsUI extends React.Component<{
 
   /** This callback will be executed by ReloadableViewport once the iModel has been loaded */
   private onIModelReady = (imodel: IModelConnection) => {
-    IModelApp.viewManager.onViewOpen.addOnce((vp: ScreenViewport) => {
+    IModelApp.viewManager.onViewOpen.addOnce((viewport: ScreenViewport) => {
 
       // Grab range of the contents of the view. We'll use this to position the random markers.
-      const range3d = vp.view.computeFitRange();
+      const range3d = viewport.view.computeFitRange();
       const range = Range2d.createFrom(range3d);
 
       // Grab the max Z for the view contents.  We'll use this as the plane for the auto-generated markers. */
       const height = range3d.zHigh;
 
-      this.setState({ imodel, range, height });
+      this.setState({ imodel, viewport, range, height });
     });
   }
 
@@ -152,7 +153,7 @@ export default class MarkerPinsUI extends React.Component<{
   public getControls() {
     return (
       <>
-        <PopupMenu />
+        <PopupMenu canvas={this.state.viewport?.canvas} />
         <div className="sample-options-2col">
           <span>Show Markers</span>
           <Toggle isOn={this.state.showDecorator} onChange={this._onChangeShowMarkers} />
@@ -181,7 +182,8 @@ export default class MarkerPinsUI extends React.Component<{
     return (
       <>
         <ControlPane instructions="Use the options below to control the marker pins.  Click a marker to open a menu of options." controls={this.getControls()} iModelSelector={this.props.iModelSelector}></ControlPane>
-        <ReloadableViewport iModelName={this.props.iModelName} onIModelReady={this.onIModelReady} getCustomViewState={MarkerPinsUI.getTopView.bind(MarkerPinsUI)} />      </>
+        <ReloadableViewport iModelName={this.props.iModelName} onIModelReady={this.onIModelReady} getCustomViewState={MarkerPinsUI.getTopView.bind(MarkerPinsUI)} />
+      </>
     );
   }
 }

--- a/src/frontend-samples/marker-pin-sample/MarkerPinUI.tsx
+++ b/src/frontend-samples/marker-pin-sample/MarkerPinUI.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import "@bentley/icons-generic-webfont/dist/bentley-icons-generic-webfont.css";
 import "common/samples-common.scss";
 import { Point3d, Range2d } from "@bentley/geometry-core";
-import { IModelApp, IModelConnection, ScreenViewport, StandardViewId, Viewport, ViewState } from "@bentley/imodeljs-frontend";
+import { IModelApp, IModelConnection, ScreenViewport, StandardViewId, ViewState } from "@bentley/imodeljs-frontend";
 import { Button, ButtonType, Toggle } from "@bentley/ui-core";
 import { PlaceMarkerTool } from "./PlaceMarkerTool";
 import { PopupMenu } from "./PopupMenu";

--- a/src/frontend-samples/marker-pin-sample/PopupMenu.tsx
+++ b/src/frontend-samples/marker-pin-sample/PopupMenu.tsx
@@ -5,6 +5,10 @@
 import * as React from "react";
 import { ContextMenuItem, GlobalContextMenu, UiEvent } from "@bentley/ui-core";
 
+export interface PopupMenuProps {
+  canvas: HTMLCanvasElement | undefined;
+}
+
 export interface PopupMenuEntry {
   label: string;
   onPicked: (entry: PopupMenuEntry) => void;
@@ -21,7 +25,7 @@ export interface PopupMenuState {
 export class PopupMenuEvent extends UiEvent<PopupMenuState> { }
 
 /** A React component that renders the UI for a simple popup menu */
-export class PopupMenu extends React.Component<{}, PopupMenuState> {
+export class PopupMenu extends React.Component<PopupMenuProps, PopupMenuState> {
 
   /** @hidden */
   public readonly state: PopupMenuState = {
@@ -47,6 +51,15 @@ export class PopupMenu extends React.Component<{}, PopupMenuState> {
     this.setState(state);
   }
 
+  // Helper method to get the offset position of an element on the browser
+  private getOffset(element: HTMLElement) {
+    const rect = element.getBoundingClientRect();
+    return {
+      left: rect.left + window.scrollX,
+      top: rect.top + window.scrollY,
+    };
+  }
+
   /** The popup menu's render method */
   public render(): React.ReactNode {
     const { entries, menuX, menuY, menuVisible } = this.state;
@@ -58,8 +71,8 @@ export class PopupMenu extends React.Component<{}, PopupMenuState> {
       return (
         <GlobalContextMenu
           identifier="popup-menu"
-          x={menuX}
-          y={menuY}
+          x={menuX + (this.props.canvas ? this.getOffset(this.props.canvas).left : 0)}
+          y={menuY + (this.props.canvas ? this.getOffset(this.props.canvas).top : 0)}
           opened={menuVisible}
           onEsc={onClose}
           onOutsideClick={onClose}

--- a/src/frontend-samples/marker-pin-sample/PopupMenu.tsx
+++ b/src/frontend-samples/marker-pin-sample/PopupMenu.tsx
@@ -64,6 +64,7 @@ export class PopupMenu extends React.Component<PopupMenuProps, PopupMenuState> {
   public render(): React.ReactNode {
     const { entries, menuX, menuY, menuVisible } = this.state;
     const onClose = this._hideContextMenu;
+    const offset = this.props.canvas ? this.getOffset(this.props.canvas) : undefined
 
     if (menuVisible) {
       const items = this.getMenuItems(entries);
@@ -71,8 +72,8 @@ export class PopupMenu extends React.Component<PopupMenuProps, PopupMenuState> {
       return (
         <GlobalContextMenu
           identifier="popup-menu"
-          x={menuX + (this.props.canvas ? this.getOffset(this.props.canvas).left : 0)}
-          y={menuY + (this.props.canvas ? this.getOffset(this.props.canvas).top : 0)}
+          x={menuX + (offset ? offset.left : 0)}
+          y={menuY + (offset ? offset.top : 0)}
           opened={menuVisible}
           onEsc={onClose}
           onOutsideClick={onClose}


### PR DESCRIPTION
Fixes the issue with the Marker Pin sample where if the editor is open the globalcontext dropdown menu that appears when a user clicks on a pen is in the wrong location.

- Passes the canvas in as a parameter to get the offset location to add to the viewport (x,y) location.