### PR TITLE
Small sample updates

### DIFF
--- a/src/frontend-samples/cross-probing-sample/ViewCreator2d.ts
+++ b/src/frontend-samples/cross-probing-sample/ViewCreator2d.ts
@@ -64,7 +64,7 @@ export class ViewCreator2d {
     const baseClassName = await this._imodel.findClassFor(modelType, undefined);
 
     if (baseClassName === undefined)
-      throw new IModelError(IModelStatus.WrongClass, "ViewCreator2d.getViewForModel: modelType is invalid", Logger.logError, loggerCategory, () => ({ modelType, modelId }))
+      throw new IModelError(IModelStatus.WrongClass, "ViewCreator2d.getViewForModel: modelType is invalid", Logger.logError.bind(Logger), loggerCategory, () => ({ modelType, modelId }))
 
     const viewState = await this._createViewState2d(modelId, baseClassName.classFullName, options);
     try {
@@ -91,7 +91,7 @@ export class ViewCreator2d {
       props = await this._addSheetViewProps(modelId, props);
       viewState = SheetViewState.createFromProps(props, this._imodel);
     } else
-      throw new IModelError(IModelStatus.WrongClass, "ViewCreator2d._createViewState2d: modelType not supported", Logger.logError, loggerCategory, () => ({ modelType, modelId }))
+      throw new IModelError(IModelStatus.WrongClass, "ViewCreator2d._createViewState2d: modelType not supported", Logger.logError.bind(Logger), loggerCategory, () => ({ modelType, modelId }))
 
     return viewState;
   }
@@ -209,10 +209,10 @@ export class ViewCreator2d {
   }
 
   /**
-    * Merges a seed view in the iModel with the passed view state props. It will be a no-op if there are no 2D views for target model.
-    * @param modelId of target model.
-    * @param props Input view props to be merged
-    */
+   * Merges a seed view in the iModel with the passed view state props. It will be a no-op if there are no 2D views for target model.
+   * @param modelId of target model.
+   * @param props Input view props to be merged
+   */
   private async _mergeSeedView(modelId: Id64String, props: ViewStateProps): Promise<ViewStateProps> {
     const viewDefinitionId = await this._getViewDefinitionsIdForModel(modelId);
     // Return incase no viewDefinition found.

--- a/src/frontend-samples/image-export/ImageExportUI.tsx
+++ b/src/frontend-samples/image-export/ImageExportUI.tsx
@@ -23,7 +23,7 @@ export default class ImageExportyUI extends React.Component<{ iModelName: string
   public getControls() {
     return (
       <div>
-        <Button buttonType={ButtonType.Hollow} onClick={ImageExportApp.exportImage}>Save as png</Button>
+        <Button buttonType={ButtonType.Hollow} onClick={ImageExportApp.exportImage.bind(ImageExportApp)}>Save as png</Button>
       </div>
     );
   }

--- a/src/frontend-samples/read-settings-sample/ReadSettingsUI.tsx
+++ b/src/frontend-samples/read-settings-sample/ReadSettingsUI.tsx
@@ -44,9 +44,9 @@ export default class ReadSettingsUI extends React.Component<ReadSettingsProps, R
       settingsInitialized: false,
       settingKey: settingsKeys[0],
     };
-    this.handleSettingsChange = this.handleSettingsChange.bind(this);
-    this.handleSettingsValueChange = this.handleSettingsValueChange.bind(this);
-    this.saveSettings = this.saveSettings.bind(this);
+    this._handleSettingsChange = this._handleSettingsChange.bind(this);
+    this._handleSettingsValueChange = this._handleSettingsValueChange.bind(this);
+    this._saveSettings = this._saveSettings.bind(this);
   }
 
   private onIModelReady = (imodel: IModelConnection) => {
@@ -58,7 +58,7 @@ export default class ReadSettingsUI extends React.Component<ReadSettingsProps, R
         settingValue: this.parseSettingsValue(settingsKeys[0], response.setting),
         settingsInitialized: true,
       });
-    })
+    });
   }
 
   private parseSettingsValue(name: string, value: string) {
@@ -70,11 +70,11 @@ export default class ReadSettingsUI extends React.Component<ReadSettingsProps, R
       default:
         _value = value || "";
     }
-    return _value
+    return _value;
   }
 
   // Handler to read external settings when name in dropdown changes
-  private handleSettingsChange(event: ChangeEvent<HTMLSelectElement>) {
+  private _handleSettingsChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const settingKey = event.target.value;
     this.setState({ settingKey });
     ReadSettingsApp.readSettings(settingKey).then((response) => {
@@ -86,13 +86,13 @@ export default class ReadSettingsUI extends React.Component<ReadSettingsProps, R
   }
 
   // Handler to get settings value into state, when you modify textarea element in the dialog
-  private handleSettingsValueChange(event: any) {
+  private _handleSettingsValueChange = (event: any) => {
     const settingValue = event.target.value;
     this.setState({ settingValue });
   }
 
   // The showcase does not have permission to write data, it is expected to fail with 403 Forbidden.
-  private saveSettings() {
+  private _saveSettings = () => {
     this.setState({ saveInProgress: true });
     ReadSettingsApp.saveSettings(this.state.settingKey!, this.state.settingValue!).then((response) => {
       this.setState({
@@ -123,14 +123,14 @@ export default class ReadSettingsUI extends React.Component<ReadSettingsProps, R
       <>
         <div className={"sample-options-2col"} style={{ gridTemplateColumns: "1fr 1fr" }}>
           <span>Settings Name:</span>
-          <Select value={this.state.settingKey} onChange={this.handleSettingsChange} style={{ width: "fit-content" }} options={settingsKeys} />
+          <Select value={this.state.settingKey} onChange={this._handleSettingsChange} style={{ width: "fit-content" }} options={settingsKeys} />
         </div>
-        <Textarea rows={10} key="test" className="uicore-full-width" value={this.state.settingValue} onChange={this.handleSettingsValueChange} />
+        <Textarea rows={10} key="test" className="uicore-full-width" value={this.state.settingValue} onChange={this._handleSettingsValueChange} />
         {this.showStatus()}
         <div style={{ height: "35px", display: "flex", alignItems: "center", justifyContent: "center" }}>
           {this.state.saveInProgress ?
             (<div ><Spinner size={SpinnerSize.Small} /> Saving...</div>) :
-            <Button onClick={this.saveSettings} disabled={!this.state.settingKey}>Save settings</Button>
+            <Button onClick={this._saveSettings} disabled={!this.state.settingKey}>Save settings</Button>
           }
         </div>
         <DisabledText>Note: save does not work in this read-only environment.</DisabledText><br />

--- a/src/frontend-samples/read-settings-sample/sampleSpec.ts
+++ b/src/frontend-samples/read-settings-sample/sampleSpec.ts
@@ -18,6 +18,6 @@ export function getReadSettingsSpec(): SampleSpec {
       { name: "index.scss", import: import("!!raw-loader!./index.scss") },
     ],
     customModelList: [SampleIModels.BayTown],
-    setup: ReadSettingsApp.setup,
+    setup: ReadSettingsApp.setup.bind(ReadSettingsApp),
   });
 }

--- a/src/frontend-samples/screen-space-effects-sample/ScreenSpaceEffectsUI.tsx
+++ b/src/frontend-samples/screen-space-effects-sample/ScreenSpaceEffectsUI.tsx
@@ -126,7 +126,7 @@ export default class ScreenSpaceEffectsUI extends React.Component<UIProps, UISta
   }
 
   private getControls(): React.ReactNode {
-    // When the view is opened, the lens angel can be outside the normal range.  This will leave it unchanged until the user adjust it.
+    // When the view is opened, the lens angle can be outside the normal range.  This will leave it unchanged until the user adjusts it.
     const lensAngleMin = 90, lensAngleMax = 160;
     let lensAngleValue = this.state.lensAngle;
     lensAngleValue = Math.min(lensAngleValue, lensAngleMax);

--- a/src/frontend-samples/screen-space-effects-sample/ScreenSpaceEffectsUI.tsx
+++ b/src/frontend-samples/screen-space-effects-sample/ScreenSpaceEffectsUI.tsx
@@ -73,9 +73,8 @@ export default class ScreenSpaceEffectsUI extends React.Component<UIProps, UISta
     });
   }
 
-  private readonly _onChangeLensAngle = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const lensAngle = Number(event.target.value);
-    this.setState({ lensAngle });
+  private readonly _onUpdateLensAngle = (values: readonly number[]) => {
+    this.setState({ lensAngle: values[0] });
   }
 
   public componentDidUpdate(_prevProp: UIProps, prevState: UIState) {
@@ -121,6 +120,12 @@ export default class ScreenSpaceEffectsUI extends React.Component<UIProps, UISta
   }
 
   private getControls(): React.ReactNode {
+    // When the view is opened, the lens angel can be outside the normal range.  This will leave it unchanged until the user adjust it.
+    const lensAngleMin = 90, lensAngleMax = 160;
+    let lensAngleValue = this.state.lensAngle;
+    lensAngleValue = Math.min(lensAngleValue, lensAngleMax);
+    lensAngleValue = Math.max(lensAngleValue, lensAngleMin);
+
     return (
       <div className={"sample-options-2col"} style={{ gridTemplateColumns: "1fr 1fr" }}>
         <span>Saturation</span>
@@ -134,7 +139,7 @@ export default class ScreenSpaceEffectsUI extends React.Component<UIProps, UISta
         <span>Lens Distortion</span>
         <Toggle isOn={this.state.enableLensDistortion} onChange={(enableLensDistortion) => this.setState({ enableLensDistortion })} />
         <span>Lens Angle</span>
-        <input type="range" min="90" max="160" step="5" value={this.state.lensAngle} onInput={this._onChangeLensAngle} disabled={!this.state.enableLensDistortion}></input>
+        <Slider showMinMax={true} min={lensAngleMin} max={lensAngleMax} step={5} values={[lensAngleValue]} disabled={!this.state.enableLensDistortion} onUpdate={this._onUpdateLensAngle} />
         {this.createSlider("Strength", this.state.effectsConfig.lensDistortion.strength, 0, 1, 0.05, "enableLensDistortion", (config, val) => config.lensDistortion.strength = val)}
         {this.createSlider("Cylindrical Ratio", this.state.effectsConfig.lensDistortion.cylindricalRatio, 0, 1, 0.05, "enableLensDistortion", (config, val) => config.lensDistortion.cylindricalRatio = val)}
       </div>

--- a/src/frontend-samples/screen-space-effects-sample/ScreenSpaceEffectsUI.tsx
+++ b/src/frontend-samples/screen-space-effects-sample/ScreenSpaceEffectsUI.tsx
@@ -28,9 +28,9 @@ interface UIProps {
 
 export default class ScreenSpaceEffectsUI extends React.Component<UIProps, UIState> {
   public state: UIState = {
-    enableSaturation: false,
-    enableVignette: false,
-    enableLensDistortion: false,
+    enableLensDistortion: true,
+    enableVignette: true,
+    enableSaturation: true,
     effectsConfig: getCurrentEffectsConfig(),
     lensAngle: 90,
   };

--- a/src/frontend-samples/screen-space-effects-sample/ScreenSpaceEffectsUI.tsx
+++ b/src/frontend-samples/screen-space-effects-sample/ScreenSpaceEffectsUI.tsx
@@ -82,14 +82,18 @@ export default class ScreenSpaceEffectsUI extends React.Component<UIProps, UISta
     if (!viewport)
       return;
 
+    // Was a new iModel opened?
+    const newViewport = this.state.viewport?.viewportId !== prevState.viewport?.viewportId;
+
     let changed = false;
     if (this.state.lensAngle !== prevState.lensAngle) {
       changed = true;
       viewport.turnCameraOn(Angle.createDegrees(this.state.lensAngle));
+      viewport.invalidateScene();
     }
 
     // Was an effect toggled on or off?
-    if (this.state.enableSaturation !== prevState.enableSaturation || this.state.enableVignette !== prevState.enableVignette || this.state.enableLensDistortion !== prevState.enableLensDistortion) {
+    if (newViewport || this.state.enableSaturation !== prevState.enableSaturation || this.state.enableVignette !== prevState.enableVignette || this.state.enableLensDistortion !== prevState.enableLensDistortion) {
       changed = true;
 
       // Screen-space effects are applied in the order in which they are added to the viewport.
@@ -147,7 +151,7 @@ export default class ScreenSpaceEffectsUI extends React.Component<UIProps, UISta
   }
 
   public render() {
-    const instructions = "Use the drop-down below to select which effect is applied to the viewport.";
+    const instructions = "Use the toggles below to select which effect is applied to the viewport.  Move the sliders to control those effects.";
     return (
       <>
         <ControlPane instructions={instructions} iModelSelector={this.props.iModelSelector} controls={this.getControls()}></ControlPane>

--- a/src/frontend-samples/screen-space-effects-sample/ScreenSpaceEffectsUI.tsx
+++ b/src/frontend-samples/screen-space-effects-sample/ScreenSpaceEffectsUI.tsx
@@ -89,7 +89,9 @@ export default class ScreenSpaceEffectsUI extends React.Component<UIProps, UISta
     if (this.state.lensAngle !== prevState.lensAngle) {
       changed = true;
       viewport.turnCameraOn(Angle.createDegrees(this.state.lensAngle));
-      viewport.invalidateScene();
+
+      // ###TODO turnCameraOn is supposed to do this, but currently doesn't. Remove once that is fixed.
+      viewport.invalidateRenderPlan();
     }
 
     // Was an effect toggled on or off?

--- a/src/frontend-samples/screen-space-effects-sample/ScreenSpaceEffectsUI.tsx
+++ b/src/frontend-samples/screen-space-effects-sample/ScreenSpaceEffectsUI.tsx
@@ -153,7 +153,7 @@ export default class ScreenSpaceEffectsUI extends React.Component<UIProps, UISta
   }
 
   public render() {
-    const instructions = "Use the toggles below to select which effect is applied to the viewport.  Move the sliders to control those effects.";
+    const instructions = "Use the toggles below to select which effects are applied to the viewport.";
     return (
       <>
         <ControlPane instructions={instructions} iModelSelector={this.props.iModelSelector} controls={this.getControls()}></ControlPane>

--- a/src/frontend-samples/swiping-viewport/Divider.tsx
+++ b/src/frontend-samples/swiping-viewport/Divider.tsx
@@ -7,8 +7,6 @@ import "./Divider.scss";
 
 export interface DividerComponentState {
   left: number;
-  bounds: ClientRect;
-  // children updates
 }
 
 export interface DividerComponentProps {
@@ -67,10 +65,7 @@ export class DividerComponent extends React.Component<DividerComponentProps, {}>
     left = Math.min(left, this.props.bounds.right - this._buffer);
     left = Math.max(left, this.props.bounds.left + this._buffer);
 
-    this.state = {
-      left,
-      bounds: props.bounds,
-    };
+    this.state = { left };
   }
 
   public componentDidUpdate(prevProps: DividerComponentProps, prevState: DividerComponentState) {
@@ -78,9 +73,7 @@ export class DividerComponent extends React.Component<DividerComponentProps, {}>
     if (currentBounds.height !== prevProps.bounds.height
       || currentBounds.width !== prevProps.bounds.width) {
       const left = ((this.state.left - prevProps.bounds.left) / prevProps.bounds.width) * this.props.bounds.width + this.props.bounds.left;
-      this.setState((_prevState, props) => {
-        return { bounds: props.bounds, left };
-      });
+      this.setState({ left });
     }
 
     if (this.state.left !== prevState.left)
@@ -124,9 +117,9 @@ export class DividerComponent extends React.Component<DividerComponentProps, {}>
       <>
         <div id={"divider-panel-left"} className={"divider-panel"}
           style={{
-            top: this.state.bounds.top,
-            height: this.state.bounds.height,
-            left: this.state.bounds.left,
+            top: this.props.bounds.top,
+            height: this.props.bounds.height,
+            left: this.props.bounds.left,
             width: this.state.left,
           }}
         >
@@ -136,8 +129,8 @@ export class DividerComponent extends React.Component<DividerComponentProps, {}>
           ref={(element) => this._container = element}
           style={{
             left: this.state.left,
-            top: this.state.bounds.top,
-            height: this.state.bounds.height,
+            top: this.props.bounds.top,
+            height: this.props.bounds.height,
           }}
           id={"divider-div"}
           onMouseDown={this._mouseDownDraggable}
@@ -146,10 +139,10 @@ export class DividerComponent extends React.Component<DividerComponentProps, {}>
         </div>
         <div id={"divider-panel-right"} className={"divider-panel"}
           style={{
-            top: this.state.bounds.top,
-            height: this.state.bounds.height,
+            top: this.props.bounds.top,
+            height: this.props.bounds.height,
             left: this.state.left,
-            width: this.state.bounds.right - this.state.left,
+            width: this.props.bounds.right - this.state.left,
           }}
         >
           {this.props.rightChildren}

--- a/src/frontend-samples/swiping-viewport/Divider.tsx
+++ b/src/frontend-samples/swiping-viewport/Divider.tsx
@@ -78,7 +78,9 @@ export class DividerComponent extends React.Component<DividerComponentProps, {}>
     if (currentBounds.height !== prevProps.bounds.height
       || currentBounds.width !== prevProps.bounds.width) {
       const left = ((this.state.left - prevProps.bounds.left) / prevProps.bounds.width) * this.props.bounds.width + this.props.bounds.left;
-      this.setState({ bounds: this.props.bounds, left });
+      this.setState((_prevState, props) => {
+        return { bounds: props.bounds, left };
+      });
     }
 
     if (this.state.left !== prevState.left)

--- a/src/frontend-samples/thematic-display-sample/ThematicDisplayUI.tsx
+++ b/src/frontend-samples/thematic-display-sample/ThematicDisplayUI.tsx
@@ -34,10 +34,10 @@ interface ThematicDisplaySampleUIProps {
 
 function mapOptions(o: {}): {} {
   const keys = Object.keys(o).filter((key: any) => isNaN(key));
-  return Object.assign({}, keys);
+  return keys.map((label, index) => {
+    return { label, value: index, disabled: false };
+  });
 }
-const _defaultAzimuth = 315.0;
-const _defaultElevation = 45.0;
 
 /** A React component that renders the UI specific for this sample */
 export default class ThematicDisplayUI extends React.Component<ThematicDisplaySampleUIProps, SampleState> {
@@ -243,8 +243,8 @@ export default class ThematicDisplayUI extends React.Component<ThematicDisplaySa
 
     const gradientModeOptions = mapOptions(ThematicGradientMode);
     if (this.state.displayMode !== ThematicDisplayMode.Height) {
-      delete (gradientModeOptions as any)[ThematicGradientMode.IsoLines];
-      delete (gradientModeOptions as any)[ThematicGradientMode.SteppedWithDelimiter];
+      (gradientModeOptions as any)[ThematicGradientMode.IsoLines].disabled = true;
+      (gradientModeOptions as any)[ThematicGradientMode.SteppedWithDelimiter].disabled = true;
     }
 
     const displayModeOptions = mapOptions(ThematicDisplayMode);

--- a/src/frontend-samples/thematic-display-sample/ThematicDisplayUI.tsx
+++ b/src/frontend-samples/thematic-display-sample/ThematicDisplayUI.tsx
@@ -239,7 +239,7 @@ export default class ThematicDisplayUI extends React.Component<ThematicDisplaySa
   public getControls() {
 
     const colorSchemeOptions = mapOptions(ThematicGradientColorScheme);
-    delete (colorSchemeOptions as any)[ThematicGradientColorScheme.Custom]; // Custom options are not supported for this sample.
+    delete (colorSchemeOptions as any)[ThematicGradientColorScheme.Custom]; // Custom colors are not supported for this sample.
 
     const gradientModeOptions = mapOptions(ThematicGradientMode);
     if (this.state.displayMode !== ThematicDisplayMode.Height) {
@@ -286,11 +286,11 @@ export default class ThematicDisplayUI extends React.Component<ThematicDisplaySa
             </span> : <span style={{ display: "flex", flexDirection: "column" }}>
               <span style={{ display: "flex", flexDirection: "row" }}>
                 <label style={{ marginRight: 7 }}>Azimuth</label>
-                <Slider min={0} max={360} step={1} values={[this.state.azimuth]} onUpdate={(values) => { this.setState({azimuth: values[0]}); }} />
+                <Slider min={0} max={360} step={1} values={[this.state.azimuth]} onUpdate={(values) => { this.setState({ azimuth: values[0] }); }} />
               </span>
               <span style={{ display: "flex", flexDirection: "row" }}>
                 <label style={{ marginRight: 7 }}>Elevation</label>
-                <Slider min={0} max={90} step={1} values={[this.state.elevation]} onUpdate={(values) => { this.setState({elevation: values[0]}); }} />
+                <Slider min={0} max={90} step={1} values={[this.state.elevation]} onUpdate={(values) => { this.setState({ elevation: values[0] }); }} />
               </span>
             </span>}
         </div>


### PR DESCRIPTION
UI fixes on the thematic display and screen space samples and lint warnings.

Screen space sample
- Screen space sample instructions needed to be updated.
- Screen space sample used html input element instead of ui-core Slider.
- Screen space sample effects and UI did not match when changing iModels.

Thematic Display
- Thematic Display Select components now disable options that are not supported in selected display mode.  (A feature I requested from the UI-Core team)

Lint Warnings
- Thematic Display sample had unused variables.
- cross-proding-sample/ViewCreator2d.ts Unbound methods
- cross-proding-sample/ViewCreator2d.ts tsdoc spacing.
- Image export sample UI Unbound method
- Read Settings sample  Unbound methods
- ReadSettingsUI missing semicolons
- Divider.tsx of the Swiping viewport sample called this.props in this.setState method.