### PR TITLE
Geometry bug

### DIFF
--- a/src/common/Geometry/BlankViewport.tsx
+++ b/src/common/Geometry/BlankViewport.tsx
@@ -61,12 +61,15 @@ export class BlankViewport extends React.Component<BlankViewportProps, { imodel:
       viewState.setAllow3dManipulations(false);
       viewState.setStandardRotation(StandardViewId.Top);
     }
+    const flags = viewState.viewFlags.clone()
+    flags.grid = true;
+    flags.renderMode = RenderMode.SmoothShade
+    viewState.displayStyle.viewFlags = flags;
     viewState.displayStyle.backgroundColor = ColorDef.white;
     if (grid)
       viewState.viewFlags.grid = true;
     else
       viewState.viewFlags.grid = false;
-    viewState.viewFlags.renderMode = RenderMode.SmoothShade;
     return viewState;
   }
 

--- a/src/common/Geometry/BlankViewport.tsx
+++ b/src/common/Geometry/BlankViewport.tsx
@@ -62,14 +62,15 @@ export class BlankViewport extends React.Component<BlankViewportProps, { imodel:
       viewState.setStandardRotation(StandardViewId.Top);
     }
     const flags = viewState.viewFlags.clone()
-    flags.grid = true;
     flags.renderMode = RenderMode.SmoothShade
-    viewState.displayStyle.viewFlags = flags;
     viewState.displayStyle.backgroundColor = ColorDef.white;
     if (grid)
-      viewState.viewFlags.grid = true;
+      flags.grid = true;
     else
-      viewState.viewFlags.grid = false;
+      flags.grid = false;
+
+    viewState.displayStyle.viewFlags = flags;
+
     return viewState;
   }
 


### PR DESCRIPTION
Fixed issue with geometry samples not rendering correctly.

After tracing through a bunch of calls to viewState, I found out that I was the source of the problem :/

I was setting the viewFlags incorrectly in the BlankViewport, which caused the jsonProperties to not get updated in the viewState, which became a problem with version 10 of iModel.js, since the Viewport Component now utilizes the jsonProperties to clone the viewState.

