### PR TITLE
Gallery item selection change handler overrides signin-callback url

### DIFF
--- a/src/Components/SampleShowcase/ActiveSample.ts
+++ b/src/Components/SampleShowcase/ActiveSample.ts
@@ -57,23 +57,24 @@ export class ActiveSample {
 }
 
 const updateURLParams = (group: string, sample: string, imodel?: string) => {
-  const params = new URLSearchParams({ group, sample });
-  // params.append("group", group);
-  // params.append("sample", sample);
+  const url = new URL(window.location.href);
+  if (!url.pathname.includes("signin-callback")) {
+    const params = new URLSearchParams({ group, sample });
 
-  if (imodel) {
-    params.append("imodel", imodel);
-  }
+    if (imodel) {
+      params.append("imodel", imodel);
+    }
 
-  // Detect if editor was enabled in URL params as a semi-backdoor, this
-  // bypasses the ld feature flag
-  const editorEnabled = new URLSearchParams(window.location.search).get("editor");
-  if (editorEnabled) params.append("editor", editorEnabled);
+    // Detect if editor was enabled in URL params as a semi-backdoor, this
+    // bypasses the ld feature flag
+    const editorEnabled = new URLSearchParams(window.location.search).get("editor");
+    if (editorEnabled) params.append("editor", editorEnabled);
 
-  window.history.pushState(null, "", `?${params.toString()}`);
+    window.history.pushState(null, "", `?${params.toString()}`);
 
-  // Send to parent if within an iframe.
-  if (window.self !== window.top) {
-    window.parent.postMessage(`?${params.toString()}`, "*");
+    // Send to parent if within an iframe.
+    if (window.self !== window.top) {
+      window.parent.postMessage(`?${params.toString()}`, "*");
+    }
   }
 };

--- a/src/SampleBaseApp.ts
+++ b/src/SampleBaseApp.ts
@@ -91,9 +91,8 @@ export class SampleBaseApp {
     const oidcConfig: BrowserAuthorizationClientConfiguration = { clientId, redirectUri, scope, responseType };
     await BrowserAuthorizationCallbackHandler.handleSigninCallback(oidcConfig.redirectUri);
     // Setup the IModelApp authorization client
-    IModelApp.authorizationClient = new BrowserAuthorizationClient(oidcConfig); 
+    IModelApp.authorizationClient = new BrowserAuthorizationClient(oidcConfig);
     */
-
 
     // Comment this block to disable no-signin.
     const authClient = new NoSignInIAuthClient();

--- a/src/SampleBaseApp.ts
+++ b/src/SampleBaseApp.ts
@@ -83,7 +83,7 @@ export class SampleBaseApp {
 
   private static async initializeOidc() {
     // Gather configuration out of the environment
-    /*  Uncomment this block to enable signin.
+    /* Uncomment this block to enable signin.
     const clientId = Config.App.get("imjs_frontend_sample_client_id", "imodeljs-spa-samples-2686");
     const redirectUri = Config.App.get("imjs_frontend_sample_redirect_uri", "http://localhost:3000/signin-callback.html");
     const scope = Config.App.get("imjs_frontend_sample_scope", "openid email profile organization imodelhub context-registry-service:read-only product-settings-service general-purpose-imodeljs-backend imodeljs-router");
@@ -91,8 +91,9 @@ export class SampleBaseApp {
     const oidcConfig: BrowserAuthorizationClientConfiguration = { clientId, redirectUri, scope, responseType };
     await BrowserAuthorizationCallbackHandler.handleSigninCallback(oidcConfig.redirectUri);
     // Setup the IModelApp authorization client
-    IModelApp.authorizationClient = new BrowserAuthorizationClient(oidcConfig); ..
+    IModelApp.authorizationClient = new BrowserAuthorizationClient(oidcConfig); 
     */
+
 
     // Comment this block to disable no-signin.
     const authClient = new NoSignInIAuthClient();


### PR DESCRIPTION
Gallery item selection change handler is hit earlier than oauth redirect handler. It causes url to be overwritten with selected gallery item query string, therefore code and state query string parameters supplied by authority are lost.