### PR TITLE
Copied ViewSetup changes to iTwin Viewer samples

### DIFF
--- a/src/@itwinjs-sandbox/view/ViewSetup.ts
+++ b/src/@itwinjs-sandbox/view/ViewSetup.ts
@@ -2,10 +2,11 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { Id64, Id64Array, Id64String } from "@bentley/bentleyjs-core";
-import { BackgroundMapProps, ColorDef } from "@bentley/imodeljs-common";
+import { Id64, Id64Array, Id64Set, Id64String } from "@bentley/bentleyjs-core";
+import { BackgroundMapProps, ColorDef, PlanarClipMaskMode, PlanarClipMaskSettings } from "@bentley/imodeljs-common";
 import { AuthorizedFrontendRequestContext, DrawingViewState, Environment, IModelApp, IModelConnection, SpatialViewState, ViewState } from "@bentley/imodeljs-frontend";
 import { SettingsMapResult, SettingsStatus } from "@bentley/product-settings-client";
+
 export class ViewSetup {
   /** Queries for and loads the default view for an iModel. */
   public static getDefaultView = async (imodel: IModelConnection): Promise<ViewState> => {
@@ -83,11 +84,60 @@ export class ViewSetup {
           nadirColor: ColorDef.computeTbgrFromComponents(64, 74, 66),
         },
       });
+
+      // Enable model masking on the metrostation model.
+      if (imodel.name === "Metrostation2") {
+        const modelIds = await ViewSetup.getModelIds(imodel);
+        const subCategoryIds = await this.getSubCategoryIds(imodel, "S-SLAB-CONC");
+        displayStyle.changeBackgroundMapProps({
+          planarClipMask: PlanarClipMaskSettings.create(PlanarClipMaskMode.IncludeSubCategories, modelIds, subCategoryIds),
+        });
+      }
+    }
+
+    if (viewState.isSpatialView()) {
+      const displayStyle = viewState.getDisplayStyle3d();
+      // Enable model masking on the Stadium model.
+      if (imodel.name === "Stadium") {
+        const modelsForMasking = await ViewSetup.getModelIds(imodel, "SS_MasterLandscape.dgn, LandscapeModel");
+        displayStyle.changeBackgroundMapProps({
+          planarClipMask: PlanarClipMaskSettings.create(PlanarClipMaskMode.Models, modelsForMasking),
+        });
+        const excludedModelIds = await ViewSetup.getModelIds(imodel,
+          "SS_Master",
+          "SS_Master_Structural.dgn, 3D Metric Design",
+          "LandscapeDetails.dgn, 3D Metric Design",
+          "Stencil Model-4-LandscapeModel, SS_MasterLandscape, SS_MasterLandscape.dgn, Road_Marking",
+        );
+        excludedModelIds.forEach((id) => viewState.modelSelector.dropModels(id));
+      }
     }
 
     const hiddenCategories = await ViewSetup.getHiddenCategories(imodel);
     if (hiddenCategories)
       viewState.categorySelector.dropCategories(hiddenCategories);
+  }
+
+  /** Returns a set of every model's id in the iModel. */
+  public static async getModelIds(iModel: IModelConnection, ...modelNames: string[]): Promise<Id64Set> {
+    const query = `SELECT ECInstanceId FROM Bis:PhysicalPartition${modelNames.length > 0 ? ` WHERE codeValue IN ('${modelNames.join("','")}')` : ""}`;
+    const ids = new Set<string>();
+    for await (const row of iModel.query(query)) {
+      ids.add(row.id);
+    }
+    return ids;
+  }
+
+  /** Returns a set of every sub category in the specified category codes. */
+  public static async getSubCategoryIds(iModel: IModelConnection, ...categoryCodes: string[]): Promise<Id64Set> {
+    const selectRelevantCategories = `SELECT ECInstanceId FROM BisCore.SpatialCategory ${categoryCodes.length > 0 ? `WHERE CodeValue IN ('${categoryCodes.join("','")}')` : ""}`;
+    const subcategoriesIds = new Set<string>();
+    for await (const row of iModel.query(selectRelevantCategories)) {
+      const ids = iModel.subcategories.getSubCategories(row.id);
+      if (ids !== undefined)
+        ids.forEach((id) => subcategoriesIds.add(id));
+    }
+    return subcategoriesIds;
   }
 
   /** Queries for categories that are unnecessary in the context of the of the sample showcase. */


### PR DESCRIPTION
The recent improvements to the view setup were not reflected in the Viewer based samples.  This was because they use a separate "ViewSetup.ts" file.

This PR copies the recent changes to the Viewer's View Setup file.