### PR TITLE
Enabled New sky box

### DIFF
--- a/src/@itwinjs-sandbox/view/ViewSetup.ts
+++ b/src/@itwinjs-sandbox/view/ViewSetup.ts
@@ -77,7 +77,7 @@ export class ViewSetup {
         displayStyle.changeBackgroundMapProps({ groundBias });
       }
 
-      // Enable the sky-box, but override to new sky box.
+      // Enable the sky-box, but override to old sky box.
       displayStyle.environment = new Environment({
         sky: {
           display: true,
@@ -87,24 +87,12 @@ export class ViewSetup {
         },
       });
 
+      // Enable model masking on the metrostation model.
       if (imodel.name === "Metrostation2") {
-        // Enable model masking on the metrostation model.
         const modelIds = await ViewSetup.getModelIds(imodel);
         const subCategoryIds = await this.getSubCategoryIds(imodel, "S-SLAB-CONC");
         displayStyle.changeBackgroundMapProps({
           planarClipMask: PlanarClipMaskSettings.create(PlanarClipMaskMode.IncludeSubCategories, modelIds, subCategoryIds),
-        });
-        // Enable original sky box.
-        displayStyle.environment = new Environment({
-          sky: {
-            display: true,
-            twoColor: false,
-            zenithColor: ColorDef.computeTbgrFromComponents(54, 117, 255),
-            skyColor: ColorDef.computeTbgrFromComponents(143, 205, 255),
-            groundColor: ColorDef.computeTbgrFromComponents(143, 163, 148),
-            // Overridden from the original, ugly brown color.
-            nadirColor: ColorDef.computeTbgrFromComponents(64, 74, 66),
-          },
         });
       }
     }

--- a/src/@itwinjs-sandbox/view/ViewSetup.ts
+++ b/src/@itwinjs-sandbox/view/ViewSetup.ts
@@ -99,9 +99,9 @@ export class ViewSetup {
           sky: {
             display: true,
             twoColor: false,
-            zenithColor: ColorDef.computeTbgrFromString("#FF7536"),
-            skyColor: ColorDef.computeTbgrFromString("#FFCD8F"),
-            groundColor: ColorDef.computeTbgrFromString("#94A38F"),
+            zenithColor: ColorDef.computeTbgrFromComponents(54, 117, 255),
+            skyColor: ColorDef.computeTbgrFromComponents(143, 205, 255),
+            groundColor: ColorDef.computeTbgrFromComponents(143, 163, 148),
             // Overridden from the original, ugly brown color.
             nadirColor: ColorDef.computeTbgrFromComponents(64, 74, 66),
           },

--- a/src/@itwinjs-sandbox/view/ViewSetup.ts
+++ b/src/@itwinjs-sandbox/view/ViewSetup.ts
@@ -77,11 +77,13 @@ export class ViewSetup {
         displayStyle.changeBackgroundMapProps({ groundBias });
       }
 
-      // Enable the sky-box, but override the ugly brown color.
+      // Enable the sky-box, but override to new sky box.
       displayStyle.environment = new Environment({
         sky: {
           display: true,
-          nadirColor: ColorDef.computeTbgrFromComponents(64, 74, 66),
+          twoColor: true,
+          zenithColor: ColorDef.computeTbgrFromString("#DEF2FF"),
+          nadirColor: ColorDef.computeTbgrFromString("#F0ECE8"),
         },
       });
 

--- a/src/@itwinjs-sandbox/view/ViewSetup.ts
+++ b/src/@itwinjs-sandbox/view/ViewSetup.ts
@@ -87,12 +87,24 @@ export class ViewSetup {
         },
       });
 
-      // Enable model masking on the metrostation model.
       if (imodel.name === "Metrostation2") {
+        // Enable model masking on the metrostation model.
         const modelIds = await ViewSetup.getModelIds(imodel);
         const subCategoryIds = await this.getSubCategoryIds(imodel, "S-SLAB-CONC");
         displayStyle.changeBackgroundMapProps({
           planarClipMask: PlanarClipMaskSettings.create(PlanarClipMaskMode.IncludeSubCategories, modelIds, subCategoryIds),
+        });
+        // Enable original sky box.
+        displayStyle.environment = new Environment({
+          sky: {
+            display: true,
+            twoColor: false,
+            zenithColor: ColorDef.computeTbgrFromString("#FF7536"),
+            skyColor: ColorDef.computeTbgrFromString("#FFCD8F"),
+            groundColor: ColorDef.computeTbgrFromString("#94A38F"),
+            // Overridden from the original, ugly brown color.
+            nadirColor: ColorDef.computeTbgrFromComponents(64, 74, 66),
+          },
         });
       }
     }

--- a/src/api/viewSetup.ts
+++ b/src/api/viewSetup.ts
@@ -99,9 +99,9 @@ export class ViewSetup {
           sky: {
             display: true,
             twoColor: false,
-            zenithColor: ColorDef.computeTbgrFromString("#FF7536"),
-            skyColor: ColorDef.computeTbgrFromString("#FFCD8F"),
-            groundColor: ColorDef.computeTbgrFromString("#94A38F"),
+            zenithColor: ColorDef.computeTbgrFromComponents(54, 117, 255),
+            skyColor: ColorDef.computeTbgrFromComponents(143, 205, 255),
+            groundColor: ColorDef.computeTbgrFromComponents(143, 163, 148),
             // Overridden from the original, ugly brown color.
             nadirColor: ColorDef.computeTbgrFromComponents(64, 74, 66),
           },

--- a/src/api/viewSetup.ts
+++ b/src/api/viewSetup.ts
@@ -77,7 +77,7 @@ export class ViewSetup {
         displayStyle.changeBackgroundMapProps({ groundBias });
       }
 
-      // Enable updated, two color sky box.
+      // Enable the sky-box, but override to old sky box.
       displayStyle.environment = new Environment({
         sky: {
           display: true,
@@ -87,24 +87,12 @@ export class ViewSetup {
         },
       });
 
+      // Enable model masking on the metrostation model.
       if (imodel.name === "Metrostation2") {
-        // Enable model masking on the metrostation model.
         const modelIds = await ViewSetup.getModelIds(imodel);
         const subCategoryIds = await this.getSubCategoryIds(imodel, "S-SLAB-CONC");
         displayStyle.changeBackgroundMapProps({
           planarClipMask: PlanarClipMaskSettings.create(PlanarClipMaskMode.IncludeSubCategories, modelIds, subCategoryIds),
-        });
-        // Enable original sky box.
-        displayStyle.environment = new Environment({
-          sky: {
-            display: true,
-            twoColor: false,
-            zenithColor: ColorDef.computeTbgrFromComponents(54, 117, 255),
-            skyColor: ColorDef.computeTbgrFromComponents(143, 205, 255),
-            groundColor: ColorDef.computeTbgrFromComponents(143, 163, 148),
-            // Overridden from the original, ugly brown color.
-            nadirColor: ColorDef.computeTbgrFromComponents(64, 74, 66),
-          },
         });
       }
     }

--- a/src/api/viewSetup.ts
+++ b/src/api/viewSetup.ts
@@ -87,12 +87,24 @@ export class ViewSetup {
         },
       });
 
-      // Enable model masking on the metrostation model.
       if (imodel.name === "Metrostation2") {
+        // Enable model masking on the metrostation model.
         const modelIds = await ViewSetup.getModelIds(imodel);
         const subCategoryIds = await this.getSubCategoryIds(imodel, "S-SLAB-CONC");
         displayStyle.changeBackgroundMapProps({
           planarClipMask: PlanarClipMaskSettings.create(PlanarClipMaskMode.IncludeSubCategories, modelIds, subCategoryIds),
+        });
+        // Enable original sky box.
+        displayStyle.environment = new Environment({
+          sky: {
+            display: true,
+            twoColor: false,
+            zenithColor: ColorDef.computeTbgrFromString("#FF7536"),
+            skyColor: ColorDef.computeTbgrFromString("#FFCD8F"),
+            groundColor: ColorDef.computeTbgrFromString("#94A38F"),
+            // Overridden from the original, ugly brown color.
+            nadirColor: ColorDef.computeTbgrFromComponents(64, 74, 66),
+          },
         });
       }
     }

--- a/src/api/viewSetup.ts
+++ b/src/api/viewSetup.ts
@@ -77,11 +77,13 @@ export class ViewSetup {
         displayStyle.changeBackgroundMapProps({ groundBias });
       }
 
-      // Enable the sky-box, but override the ugly brown color.
+      // Enable updated, two color sky box.
       displayStyle.environment = new Environment({
         sky: {
           display: true,
-          nadirColor: ColorDef.computeTbgrFromComponents(64, 74, 66),
+          twoColor: true,
+          zenithColor: ColorDef.computeTbgrFromString("#DEF2FF"),
+          nadirColor: ColorDef.computeTbgrFromString("#F0ECE8"),
         },
       });
 


### PR DESCRIPTION
Enabled the new sky box for all iModels.
![image](https://user-images.githubusercontent.com/30239292/116150658-47401d00-a6a9-11eb-8b53-3067f7e9f7b7.png)

For consideration: The iModels with the background map enabled by default, such as the stadium, could use the old sky box with more of a horizon.  I decided that the sky box look just as good on these iModels too.