### PR TITLE
Svg minimize icon in control pane fix

### DIFF
--- a/src/common/ControlPane/ControlPane.scss
+++ b/src/common/ControlPane/ControlPane.scss
@@ -35,6 +35,8 @@
   flex-direction: row;
 
   .control-pane-minimize {
+    width: 20px;
+    height: 20px;
     padding: 0;
   }
 


### PR DESCRIPTION
The svg minimize icon in the non-itwinviewer samples took up half the control pane. This PR fixes that