### PR TITLE
Simplify EmphasizeElementsApi

### DIFF
--- a/src/frontend-samples/emphasize-elements-sample/EmphasizeElementsApi.tsx
+++ b/src/frontend-samples/emphasize-elements-sample/EmphasizeElementsApi.tsx
@@ -2,92 +2,50 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-
 import "common/samples-common.scss";
-import { EmphasizeElements, FeatureOverrideType, IModelApp, ScreenViewport } from "@bentley/imodeljs-frontend";
+import { EmphasizeElements, FeatureOverrideType, ScreenViewport } from "@bentley/imodeljs-frontend";
 import { ColorDef } from "@bentley/imodeljs-common";
 
-abstract class EmphasizeActionBase {
-  protected abstract execute(emph: EmphasizeElements, vp: ScreenViewport): boolean;
+export class EmphasizeElementsApi {
 
-  public run(): boolean {
-    const vp = IModelApp.viewManager.selectedView;
-
-    if (undefined === vp) {
-      return false;
-    }
-
+  public static emphasizeSelectedElements(wantEmphasis: boolean, vp: ScreenViewport) {
     const emph = EmphasizeElements.getOrCreate(vp);
-    return this.execute(emph, vp);
-  }
-}
-
-export class EmphasizeAction extends EmphasizeActionBase {
-  private _wantEmphasis: boolean;
-
-  public constructor(wantEmphasis: boolean) {
-    super();
-    this._wantEmphasis = wantEmphasis;
-  }
-  public execute(emph: EmphasizeElements, vp: ScreenViewport): boolean {
-    emph.wantEmphasis = this._wantEmphasis;
+    emph.wantEmphasis = wantEmphasis;
     emph.emphasizeSelectedElements(vp);
-    return true;
   }
-}
 
-export class ClearEmphasizeAction extends EmphasizeActionBase {
-  public execute(emph: EmphasizeElements, vp: ScreenViewport): boolean {
+  public static clearEmphasizedElements(vp: ScreenViewport) {
+    const emph = EmphasizeElements.getOrCreate(vp);
     emph.clearEmphasizedElements(vp);
-    return true;
   }
-}
 
-export class HideAction extends EmphasizeActionBase {
-  public execute(emph: EmphasizeElements, vp: ScreenViewport): boolean {
+  public static hideSelectedElements(vp: ScreenViewport) {
+    const emph = EmphasizeElements.getOrCreate(vp);
     emph.hideSelectedElements(vp);
-    return true;
   }
-}
 
-export class ClearHideAction extends EmphasizeActionBase {
-  public execute(emph: EmphasizeElements, vp: ScreenViewport): boolean {
+  public static clearHiddenElements(vp: ScreenViewport) {
+    const emph = EmphasizeElements.getOrCreate(vp);
     emph.clearHiddenElements(vp);
-    return true;
   }
-}
 
-export class IsolateAction extends EmphasizeActionBase {
-  public execute(emph: EmphasizeElements, vp: ScreenViewport): boolean {
+  public static isolateSelectedElements(vp: ScreenViewport) {
+    const emph = EmphasizeElements.getOrCreate(vp);
     emph.isolateSelectedElements(vp);
-    return true;
   }
-}
 
-export class ClearIsolateAction extends EmphasizeActionBase {
-  public execute(emph: EmphasizeElements, vp: ScreenViewport): boolean {
+  public static clearIsolatedElements(vp: ScreenViewport) {
+    const emph = EmphasizeElements.getOrCreate(vp);
     emph.clearIsolatedElements(vp);
-    return true;
-  }
-}
-
-export class OverrideAction extends EmphasizeActionBase {
-  private _colorValue: ColorDef;
-
-  public constructor(colorValue: ColorDef) {
-    super();
-    this._colorValue = colorValue;
   }
 
-  public execute(emph: EmphasizeElements, vp: ScreenViewport): boolean {
-    emph.overrideSelectedElements(vp, this._colorValue, FeatureOverrideType.ColorOnly, false, true);
-    return true;
+  public static overrideSelectedElements(colorValue: ColorDef, vp: ScreenViewport) {
+    const emph = EmphasizeElements.getOrCreate(vp);
+    emph.overrideSelectedElements(vp, colorValue, FeatureOverrideType.ColorOnly, false, true);
   }
-}
 
-export class ClearOverrideAction extends EmphasizeActionBase {
-  public execute(emph: EmphasizeElements, vp: ScreenViewport): boolean {
+  public static clearOverriddenElements(vp: ScreenViewport) {
+    const emph = EmphasizeElements.getOrCreate(vp);
     emph.clearOverriddenElements(vp);
-    return true;
   }
 }

--- a/src/frontend-samples/emphasize-elements-sample/EmphasizeElementsWidget.tsx
+++ b/src/frontend-samples/emphasize-elements-sample/EmphasizeElementsWidget.tsx
@@ -2,12 +2,11 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-
 import React, { useEffect } from "react";
 import { ColorDef } from "@bentley/imodeljs-common";
 import { Button, ButtonType, Toggle } from "@bentley/ui-core";
 import { ColorPickerButton } from "@bentley/ui-components";
-import { ClearEmphasizeAction, ClearHideAction, ClearIsolateAction, ClearOverrideAction, EmphasizeAction, HideAction, IsolateAction, OverrideAction } from "./EmphasizeElementsApi";
+import { EmphasizeElementsApi } from "./EmphasizeElementsApi";
 import { ISelectionProvider, Presentation, SelectionChangeEventArgs } from "@bentley/presentation-frontend";
 import { AbstractWidgetProps, StagePanelLocation, StagePanelSection, UiItemsProvider, WidgetState } from "@bentley/ui-abstract";
 import { EmphasizeElements, IModelApp } from "@bentley/imodeljs-frontend";
@@ -57,52 +56,62 @@ export const EmphasizeElementsWidget: React.FunctionComponent = () => {
   };
 
   const _handleActionButton = (type: ActionType) => {
+    const vp = IModelApp.viewManager.selectedView;
+
+    if (undefined === vp)
+      return;
+
     switch (type) {
       default:
       case ActionType.Emphasize: {
-        if (new EmphasizeAction(wantEmphasisState).run())
-          setEmphasizeIsActiveState(true);
+        EmphasizeElementsApi.emphasizeSelectedElements(wantEmphasisState, vp);
+        setEmphasizeIsActiveState(true);
         break;
       }
       case ActionType.Isolate: {
-        if (new IsolateAction().run())
-          setIsolateIsActiveState(true);
+        EmphasizeElementsApi.isolateSelectedElements(vp);
+        setIsolateIsActiveState(true);
         break;
       }
       case ActionType.Hide: {
-        if (new HideAction().run())
-          setHideIsActiveState(true);
+        EmphasizeElementsApi.hideSelectedElements(vp);
+        setHideIsActiveState(true);
         break;
       }
       case ActionType.Override: {
-        if (new OverrideAction(colorValueState).run())
-          setOverrideIsActiveState(true);
+        EmphasizeElementsApi.overrideSelectedElements(colorValueState, vp);
+        setOverrideIsActiveState(true);
         break;
       }
     }
   };
 
   const _handleClearButton = (type: ActionType) => {
+    const vp = IModelApp.viewManager.selectedView;
+
+    if (undefined === vp)
+      return;
+
     switch (type) {
       default:
       case ActionType.Emphasize: {
-        if (new ClearEmphasizeAction().run())
-          setEmphasizeIsActiveState(false);
+        EmphasizeElementsApi.clearEmphasizedElements(vp);
+        setEmphasizeIsActiveState(false);
         break;
       }
       case ActionType.Isolate: {
-        if (new ClearIsolateAction().run())
-          setIsolateIsActiveState(false);
+        EmphasizeElementsApi.clearIsolatedElements(vp);
+        setIsolateIsActiveState(false);
         break;
       }
       case ActionType.Hide: {
-        if (new ClearHideAction().run())
-          setHideIsActiveState(false);
+        EmphasizeElementsApi.clearHiddenElements(vp);
+        setHideIsActiveState(false);
         break;
       }
       case ActionType.Override: {
-        if (new ClearOverrideAction().run())
-          setOverrideIsActiveState(false);
+        EmphasizeElementsApi.clearOverriddenElements(vp);
+        setOverrideIsActiveState(false);
         break;
       }
     }

--- a/src/test/frontend-sample-showcase.test.tsx
+++ b/src/test/frontend-sample-showcase.test.tsx
@@ -10,7 +10,7 @@ import { Range3d } from "@bentley/geometry-core";
 import { ContextRealityModelProps, SpatialClassificationProps } from "@bentley/imodeljs-common";
 import { EmphasizeElements, IModelApp, IModelAppOptions, IModelConnection, MockRender, ScreenViewport } from "@bentley/imodeljs-frontend";
 import { I18NNamespace } from "@bentley/imodeljs-i18n";
-import { EmphasizeAction } from "../frontend-samples/emphasize-elements-sample/EmphasizeElementsApi";
+import { EmphasizeElementsApi } from "../frontend-samples/emphasize-elements-sample/EmphasizeElementsApi";
 import ShadowStudyApp from "../frontend-samples/shadow-study-sample/ShadowStudyApi";
 import ThematicDisplayApi from "../frontend-samples/thematic-display-sample/ThematicDisplayApi";
 import ViewClipApp from "../frontend-samples/view-clip-sample/ViewClipApi";
@@ -126,12 +126,12 @@ describe("Emphasize Elements", () => {
       const oldEmphasizedElms = emphasizeElem.getEmphasizedElements(vp);
       expect(oldEmphasizedElms).to.be.undefined;
 
-      // Select some elements and run EmphasizeAction
+      // Select some elements and run emphasizeSelectedElements
       const ids = new Set<string>();
       ids.add("0x1"); ids.add("0x2"); ids.add("0x3");
 
       vp.view.iModel.selectionSet.add(ids);
-      new EmphasizeAction(true).run();
+      EmphasizeElementsApi.emphasizeSelectedElements(true, vp);
 
       // Expect emphasized elements to be changed
       expect(emphasizeElem.getEmphasizedElements(vp)).to.not.equal(oldEmphasizedElms);


### PR DESCRIPTION
Remove the unnecessarily complicated 'Action' classes in favor of simple methods for calling the emphasize API.