### PR TITLE
Fixed Bug with Gallery Image Resizing

### DIFF
--- a/src/Components/SampleGallery/SampleGallery.scss
+++ b/src/Components/SampleGallery/SampleGallery.scss
@@ -8,7 +8,7 @@
 
   .gallery-card-radio {
     background-color: #333;
-    overflow-y: auto;
+    overflow-y: scroll;
     overflow-x: hidden;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
Fixes issue with sample gallery images sometimes resizing rapidly when being hovered over. Was likely caused by the gallery height getting very close to the parent container, where hovering over an image would cause the gallery to overflow the y axis. This would cause a scrollbar to appear and take up some space, which caused the images to shrink, which would then remove the overflow, leading to the rapid resizing loop. Changing overflow-y from auto to scroll makes space for a scrollbar at all times, which fixes the issue.