### PR TITLE
Issue Markers

### DIFF
--- a/src/frontend-samples/clash-review-sample/ClashReviewApi.ts
+++ b/src/frontend-samples/clash-review-sample/ClashReviewApi.ts
@@ -26,6 +26,10 @@ export default class ClashReviewApi {
     return ClashReviewApi._requestContext;
   }
 
+  public static setupDecorator() {
+    return new MarkerPinDecorator();
+  }
+
   public static setDecoratorPoints(markersData: MarkerData[], decorator: MarkerPinDecorator, images: Map<string, HTMLImageElement>) {
     decorator.setMarkersData(markersData, images.get("clash_pin.svg")!, ClashReviewApi.visualizeClashCallback);
   }

--- a/src/frontend-samples/clash-review-sample/ClashReviewWidget.tsx
+++ b/src/frontend-samples/clash-review-sample/ClashReviewWidget.tsx
@@ -15,10 +15,10 @@ const ClashReviewWidget: React.FunctionComponent = () => {
   const [markersData, setMarkersData] = React.useState<MarkerData[]>();
   const [images, setImages] = React.useState<Map<string, HTMLImageElement>>();
 
-  const [clashPinDecorator, setClashPinDecorator] = React.useState<MarkerPinDecorator>(() => {
+  const [clashPinDecorator] = React.useState<MarkerPinDecorator>(() => {
     const decorator = new MarkerPinDecorator();
     ClashReviewApi.enableDecorations(decorator);
-    return decorator
+    return decorator;
   });
 
   useEffect(() => {
@@ -75,7 +75,7 @@ const ClashReviewWidget: React.FunctionComponent = () => {
       }
       setShowDecorator(true);
     }
-  }, [markersData, images]);
+  }, [markersData, images, clashPinDecorator]);
 
   useEffect(() => {
     if (showDecorator)

--- a/src/frontend-samples/clash-review-sample/ClashReviewWidget.tsx
+++ b/src/frontend-samples/clash-review-sample/ClashReviewWidget.tsx
@@ -15,7 +15,11 @@ const ClashReviewWidget: React.FunctionComponent = () => {
   const [markersData, setMarkersData] = React.useState<MarkerData[]>();
   const [images, setImages] = React.useState<Map<string, HTMLImageElement>>();
 
-  const [clashPinDecorator, setClashPinDecorator] = React.useState<MarkerPinDecorator | undefined>();
+  const [clashPinDecorator, setClashPinDecorator] = React.useState<MarkerPinDecorator>(() => {
+    const decorator = new MarkerPinDecorator();
+    ClashReviewApi.enableDecorations(decorator);
+    return decorator
+  });
 
   useEffect(() => {
     const newImages = new Map();
@@ -45,8 +49,7 @@ const ClashReviewWidget: React.FunctionComponent = () => {
     }
     return () => {
       removeListener();
-      if (clashPinDecorator)
-        ClashReviewApi.disableDecorations(clashPinDecorator);
+      ClashReviewApi.disableDecorations(clashPinDecorator);
     };
   }, [iModelConnection, clashPinDecorator]);
 
@@ -65,10 +68,7 @@ const ClashReviewWidget: React.FunctionComponent = () => {
 
   useEffect(() => {
     if (markersData && images) {
-      const decorator = new MarkerPinDecorator();
-      setClashPinDecorator(decorator);
-      ClashReviewApi.enableDecorations(decorator);
-      ClashReviewApi.setDecoratorPoints(markersData, decorator, images);
+      ClashReviewApi.setDecoratorPoints(markersData, clashPinDecorator, images);
       // Automatically visualize first clash
       if (markersData !== undefined && markersData.length !== 0 && markersData[0].data !== undefined) {
         ClashReviewApi.visualizeClash(markersData[0].data.elementAId, markersData[0].data.elementBId);
@@ -78,12 +78,10 @@ const ClashReviewWidget: React.FunctionComponent = () => {
   }, [markersData, images]);
 
   useEffect(() => {
-    if (clashPinDecorator) {
-      if (showDecorator)
-        ClashReviewApi.enableDecorations(clashPinDecorator);
-      else
-        ClashReviewApi.disableDecorations(clashPinDecorator);
-    }
+    if (showDecorator)
+      ClashReviewApi.enableDecorations(clashPinDecorator);
+    else
+      ClashReviewApi.disableDecorations(clashPinDecorator);
   }, [showDecorator, clashPinDecorator]);
 
   useEffect(() => {

--- a/src/frontend-samples/clash-review-sample/ClashReviewWidget.tsx
+++ b/src/frontend-samples/clash-review-sample/ClashReviewWidget.tsx
@@ -16,9 +16,7 @@ const ClashReviewWidget: React.FunctionComponent = () => {
   const [images, setImages] = React.useState<Map<string, HTMLImageElement>>();
 
   const [clashPinDecorator] = React.useState<MarkerPinDecorator>(() => {
-    const decorator = new MarkerPinDecorator();
-    ClashReviewApi.enableDecorations(decorator);
-    return decorator;
+    return ClashReviewApi.setupDecorator();
   });
 
   useEffect(() => {
@@ -32,6 +30,14 @@ const ClashReviewWidget: React.FunctionComponent = () => {
         console.error(error);
       });
   }, []);
+
+  /** Initialize Decorator */
+  useEffect(() => {
+    ClashReviewApi.enableDecorations(clashPinDecorator);
+    return () => {
+      ClashReviewApi.disableDecorations(clashPinDecorator);
+    };
+  }, [clashPinDecorator]);
 
   useEffect(() => {
     /** Create a listener that responds to clashData retrival */
@@ -49,9 +55,8 @@ const ClashReviewWidget: React.FunctionComponent = () => {
     }
     return () => {
       removeListener();
-      ClashReviewApi.disableDecorations(clashPinDecorator);
     };
-  }, [iModelConnection, clashPinDecorator]);
+  }, [iModelConnection]);
 
   /** When the clashData comes in, get the marker data */
   useEffect(() => {

--- a/src/frontend-samples/issues-sample/IssuesApi.ts
+++ b/src/frontend-samples/issues-sample/IssuesApi.ts
@@ -55,6 +55,5 @@ export default class IssuesApi {
 
   public static clearDecoratorPoints(decorator: MarkerPinDecorator) {
     decorator.clearMarkers();
-
   }
 }

--- a/src/frontend-samples/issues-sample/IssuesApi.ts
+++ b/src/frontend-samples/issues-sample/IssuesApi.ts
@@ -15,7 +15,6 @@ export interface LabelWithId extends LabelDefinition {
 }
 
 export default class IssuesApi {
-  public static _issuesPinDecorator?: MarkerPinDecorator;
 
   public static async getElementKeySet(elementsId: string) {
     if (!elementsId || elementsId.trim().length === 0)
@@ -36,37 +35,26 @@ export default class IssuesApi {
     return labels.map((label, index) => ({ ...label, id: instanceKeys[index].id }));
   }
 
-  public static decoratorIsSetup() {
-    return (null != this._issuesPinDecorator);
-  }
-
   public static setupDecorator() {
-    if (undefined === this._issuesPinDecorator)
-      this._issuesPinDecorator = new MarkerPinDecorator();
+    return new MarkerPinDecorator();
   }
 
-  public static addDecoratorPoint(issue: IssueGet, pinImage: HTMLImageElement, title?: string, description?: string, onMouseButtonCallback?: any) {
+  public static addDecoratorPoint(decorator: MarkerPinDecorator, issue: IssueGet, pinImage: HTMLImageElement, title?: string, description?: string, onMouseButtonCallback?: any) {
     const markerData: MarkerData = { point: issue.modelPin?.location ?? Point3d.createZero(), title, description, data: issue };
     const scale = { low: .2, high: 1.4 };
-    if (this._issuesPinDecorator)
-      this._issuesPinDecorator.addMarkerPoint(markerData, pinImage, title, description, scale, onMouseButtonCallback);
+    decorator.addMarkerPoint(markerData, pinImage, title, description, scale, onMouseButtonCallback);
   }
 
-  public static enableDecorations() {
-    if (this._issuesPinDecorator)
-      IModelApp.viewManager.addDecorator(this._issuesPinDecorator);
+  public static enableDecorations(decorator: MarkerPinDecorator) {
+    IModelApp.viewManager.addDecorator(decorator);
   }
 
-  public static disableDecorations() {
-    if (null != this._issuesPinDecorator) {
-      IModelApp.viewManager.dropDecorator(this._issuesPinDecorator);
-      this._issuesPinDecorator = undefined;
-    }
+  public static disableDecorations(decorator: MarkerPinDecorator) {
+    IModelApp.viewManager.dropDecorator(decorator);
   }
 
-  public static clearDecoratorPoints() {
-    if (null != this._issuesPinDecorator) {
-      this._issuesPinDecorator.clearMarkers();
-    }
+  public static clearDecoratorPoints(decorator: MarkerPinDecorator) {
+    decorator.clearMarkers();
+
   }
 }

--- a/src/frontend-samples/issues-sample/IssuesWidget.tsx
+++ b/src/frontend-samples/issues-sample/IssuesWidget.tsx
@@ -11,6 +11,7 @@ import { Body, IconButton, Leading, Subheading, Table, Tile } from "@itwin/itwin
 import IssuesClient, { AttachmentMetadataGet, AuditTrailEntryGet, CommentGetPreferReturnMinimal, IssueDetailsGet, IssueGet } from "./IssuesClient";
 import IssuesApi, { LabelWithId } from "./IssuesApi";
 import "./Issues.scss";
+import { MarkerPinDecorator } from "frontend-samples/marker-pin-sample/MarkerPinDecorator";
 
 const thumbnails: Map<string, Blob> = new Map<string, Blob>();
 
@@ -41,15 +42,18 @@ const IssuesWidget: React.FunctionComponent = () => {
   const [stateFilter, setStateFilter] = useState<string>("All");
   /** The type filter. */
   const [typeFilter, setTypeFilter] = useState<string>("All");
+  /** The decorator used for displaying issue markers */
+  const [issueDecorator] = React.useState<MarkerPinDecorator>(() => {
+    const decorator = IssuesApi.setupDecorator();
+    IssuesApi.enableDecorations(decorator);
+    return decorator
+  });
+
 
   /** Initialize Decorator */
   useEffect(() => {
-    IssuesApi.setupDecorator();
-    IssuesApi.enableDecorations();
-
     return () => {
-      IssuesApi.disableDecorations();
-      IssuesApi._issuesPinDecorator = undefined;
+      IssuesApi.disableDecorations(issueDecorator);
     };
   }, []);
 
@@ -147,7 +151,7 @@ const IssuesWidget: React.FunctionComponent = () => {
       <path id="icon" d="m10.8125 5h1.125v18h-1.125zm12.375 6.75h-10.125v-6.75h10.125l-4.5 3.375z" fill="#fff"/>
     </svg>`;
 
-    IssuesApi.clearDecoratorPoints();
+    IssuesApi.clearDecoratorPoints(issueDecorator);
 
     /** Clear the current points */
     for (const issue of currentIssues) {
@@ -179,7 +183,7 @@ const IssuesWidget: React.FunctionComponent = () => {
       }
 
       /** Add the point to the decorator */
-      IssuesApi.addDecoratorPoint(issue, svg, issue.number, issue.subject, (iss: any) => {
+      IssuesApi.addDecoratorPoint(issueDecorator, issue, svg, issue.number, issue.subject, (iss: any) => {
         applyView(iss)
           .catch((error) => {
             // eslint-disable-next-line no-console
@@ -189,7 +193,7 @@ const IssuesWidget: React.FunctionComponent = () => {
         setCurrentIssue(iss);
       });
     }
-  }, [applyView, currentIssues]);
+  }, [applyView, currentIssues, issueDecorator]);
 
   /** Returns a color corresponding to the status of the issue */
   const issueStatusColor = (issue: IssueGet) => {

--- a/src/frontend-samples/issues-sample/IssuesWidget.tsx
+++ b/src/frontend-samples/issues-sample/IssuesWidget.tsx
@@ -44,13 +44,12 @@ const IssuesWidget: React.FunctionComponent = () => {
   const [typeFilter, setTypeFilter] = useState<string>("All");
   /** The decorator used for displaying issue markers */
   const [issueDecorator] = React.useState<MarkerPinDecorator>(() => {
-    const decorator = IssuesApi.setupDecorator();
-    IssuesApi.enableDecorations(decorator);
-    return decorator;
+    return IssuesApi.setupDecorator();
   });
 
   /** Initialize Decorator */
   useEffect(() => {
+    IssuesApi.enableDecorations(issueDecorator);
     return () => {
       IssuesApi.disableDecorations(issueDecorator);
     };

--- a/src/frontend-samples/issues-sample/IssuesWidget.tsx
+++ b/src/frontend-samples/issues-sample/IssuesWidget.tsx
@@ -5,14 +5,13 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useActiveIModelConnection, useActiveViewport } from "@bentley/ui-framework";
 import { AbstractWidgetProps, StagePanelLocation, StagePanelSection, UiItemsProvider, WidgetState } from "@bentley/ui-abstract";
-import { HorizontalTabs, Select, Spinner, SpinnerSize, Timer } from "@bentley/ui-core";
+import { HorizontalTabs, Select, Spinner, SpinnerSize } from "@bentley/ui-core";
 import { Angle, Point3d, Vector3d } from "@bentley/geometry-core";
 import { Body, IconButton, Leading, Subheading, Table, Tile } from "@itwin/itwinui-react";
 import IssuesClient, { AttachmentMetadataGet, AuditTrailEntryGet, CommentGetPreferReturnMinimal, IssueDetailsGet, IssueGet } from "./IssuesClient";
 import IssuesApi, { LabelWithId } from "./IssuesApi";
 import "./Issues.scss";
 import { MarkerPinDecorator } from "frontend-samples/marker-pin-sample/MarkerPinDecorator";
-import { IModelApp } from "@bentley/imodeljs-frontend";
 
 const thumbnails: Map<string, Blob> = new Map<string, Blob>();
 
@@ -195,7 +194,7 @@ const IssuesWidget: React.FunctionComponent = () => {
     IssuesApi.clearDecoratorPoints(issueDecorator);
 
     for (const issue of currentIssues) {
-      createMarker(issue)
+      void createMarker(issue);
     }
 
   }, [applyView, currentIssues, issueDecorator]);

--- a/src/frontend-samples/issues-sample/IssuesWidget.tsx
+++ b/src/frontend-samples/issues-sample/IssuesWidget.tsx
@@ -5,13 +5,14 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useActiveIModelConnection, useActiveViewport } from "@bentley/ui-framework";
 import { AbstractWidgetProps, StagePanelLocation, StagePanelSection, UiItemsProvider, WidgetState } from "@bentley/ui-abstract";
-import { HorizontalTabs, Select, Spinner, SpinnerSize } from "@bentley/ui-core";
+import { HorizontalTabs, Select, Spinner, SpinnerSize, Timer } from "@bentley/ui-core";
 import { Angle, Point3d, Vector3d } from "@bentley/geometry-core";
 import { Body, IconButton, Leading, Subheading, Table, Tile } from "@itwin/itwinui-react";
 import IssuesClient, { AttachmentMetadataGet, AuditTrailEntryGet, CommentGetPreferReturnMinimal, IssueDetailsGet, IssueGet } from "./IssuesClient";
 import IssuesApi, { LabelWithId } from "./IssuesApi";
 import "./Issues.scss";
 import { MarkerPinDecorator } from "frontend-samples/marker-pin-sample/MarkerPinDecorator";
+import { IModelApp } from "@bentley/imodeljs-frontend";
 
 const thumbnails: Map<string, Blob> = new Map<string, Blob>();
 
@@ -193,6 +194,11 @@ const IssuesWidget: React.FunctionComponent = () => {
         setCurrentIssue(iss);
       });
     }
+    /** This timer is being used to resolve an async issue that prevents marker pin decorations from being drawn immeditately after changing the current issues */
+    const timer = new Timer(250);
+    timer.setOnExecute(() => { if (IModelApp.viewManager) IModelApp.viewManager.invalidateDecorationsAllViews() })
+    timer.start()
+
   }, [applyView, currentIssues, issueDecorator]);
 
   /** Returns a color corresponding to the status of the issue */

--- a/src/frontend-samples/issues-sample/IssuesWidget.tsx
+++ b/src/frontend-samples/issues-sample/IssuesWidget.tsx
@@ -143,18 +143,14 @@ const IssuesWidget: React.FunctionComponent = () => {
 
   /** Create the issue marker icon, then add the pin at the issue location */
   useEffect(() => {
-    const parser = new DOMParser();
-    const SVGMAP: { [key: string]: HTMLImageElement } = {};
-    const issue_marker: string = `
-    <svg viewBox="0 0 32 32" width="40" height="40" xmlns="http://www.w3.org/2000/svg"><path d="m25 0h-18a5 5 0 0 0 -5 5v18a5 5 0 0 0 5 5h5v.00177l4 3.99823 4-3.99823v-.00177h5a5 5 0 0 0 5-5v-18a5 5 0 0 0 -5-5z" fill="#fff" fill-rule="evenodd"/>
-      <path id="fill" d="m25 1a4.00453 4.00453 0 0 1 4 4v18a4.00453 4.00453 0 0 1 -4 4h-18a4.00453 4.00453 0 0 1 -4-4v-18a4.00453 4.00453 0 0 1 4-4z" fill="#008be1"/>
-      <path id="icon" d="m10.8125 5h1.125v18h-1.125zm12.375 6.75h-10.125v-6.75h10.125l-4.5 3.375z" fill="#fff"/>
-    </svg>`;
-
-    IssuesApi.clearDecoratorPoints(issueDecorator);
-
-    /** Clear the current points */
-    for (const issue of currentIssues) {
+    async function createMarker(issue: IssueGet) {
+      const parser = new DOMParser();
+      const SVGMAP: { [key: string]: HTMLImageElement } = {};
+      const issue_marker: string = `
+      <svg viewBox="0 0 32 32" width="40" height="40" xmlns="http://www.w3.org/2000/svg"><path d="m25 0h-18a5 5 0 0 0 -5 5v18a5 5 0 0 0 5 5h5v.00177l4 3.99823 4-3.99823v-.00177h5a5 5 0 0 0 5-5v-18a5 5 0 0 0 -5-5z" fill="#fff" fill-rule="evenodd"/>
+        <path id="fill" d="m25 1a4.00453 4.00453 0 0 1 4 4v18a4.00453 4.00453 0 0 1 -4 4h-18a4.00453 4.00453 0 0 1 -4-4v-18a4.00453 4.00453 0 0 1 4-4z" fill="#008be1"/>
+        <path id="icon" d="m10.8125 5h1.125v18h-1.125zm12.375 6.75h-10.125v-6.75h10.125l-4.5 3.375z" fill="#fff"/>
+      </svg>`;
       const fillColor = issueStatusColor(issue);
       let svg = SVGMAP[fillColor];
       if (!svg) {
@@ -179,6 +175,7 @@ const IssuesWidget: React.FunctionComponent = () => {
         const blob = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" });
         svg = new Image(40, 40);
         svg.src = URL.createObjectURL(blob);
+        await svg.decode();
         SVGMAP[fillColor] = svg;
       }
 
@@ -193,10 +190,13 @@ const IssuesWidget: React.FunctionComponent = () => {
         setCurrentIssue(iss);
       });
     }
-    /** This timer is being used to resolve an async issue that prevents marker pin decorations from being drawn immeditately after changing the current issues */
-    const timer = new Timer(250);
-    timer.setOnExecute(() => { if (IModelApp.viewManager) IModelApp.viewManager.invalidateDecorationsAllViews(); });
-    timer.start();
+
+    /** Clear the current points */
+    IssuesApi.clearDecoratorPoints(issueDecorator);
+
+    for (const issue of currentIssues) {
+      createMarker(issue)
+    }
 
   }, [applyView, currentIssues, issueDecorator]);
 

--- a/src/frontend-samples/issues-sample/IssuesWidget.tsx
+++ b/src/frontend-samples/issues-sample/IssuesWidget.tsx
@@ -47,16 +47,15 @@ const IssuesWidget: React.FunctionComponent = () => {
   const [issueDecorator] = React.useState<MarkerPinDecorator>(() => {
     const decorator = IssuesApi.setupDecorator();
     IssuesApi.enableDecorations(decorator);
-    return decorator
+    return decorator;
   });
-
 
   /** Initialize Decorator */
   useEffect(() => {
     return () => {
       IssuesApi.disableDecorations(issueDecorator);
     };
-  }, []);
+  }, [issueDecorator]);
 
   useEffect(() => {
     if (iModelConnection && contextId !== iModelConnection.contextId) {
@@ -196,8 +195,8 @@ const IssuesWidget: React.FunctionComponent = () => {
     }
     /** This timer is being used to resolve an async issue that prevents marker pin decorations from being drawn immeditately after changing the current issues */
     const timer = new Timer(250);
-    timer.setOnExecute(() => { if (IModelApp.viewManager) IModelApp.viewManager.invalidateDecorationsAllViews() })
-    timer.start()
+    timer.setOnExecute(() => { if (IModelApp.viewManager) IModelApp.viewManager.invalidateDecorationsAllViews(); });
+    timer.start();
 
   }, [applyView, currentIssues, issueDecorator]);
 

--- a/src/frontend-samples/marker-pin-sample/MarkerPinApi.ts
+++ b/src/frontend-samples/marker-pin-sample/MarkerPinApi.ts
@@ -11,43 +11,33 @@ import { MarkerData, MarkerPinDecorator } from "./MarkerPinDecorator";
 
 export default class MarkerPinApi {
   public static _sampleNamespace: I18NNamespace;
-  public static _markerDecorator?: MarkerPinDecorator;
   public static _images: Map<string, HTMLImageElement>;
 
-  public static decoratorIsSetup() {
-    return (null != this._markerDecorator);
-  }
-
   // START SETUPDECORATOR
-  public static setupDecorator(markersData: MarkerData[]) {
-    // If we failed to load the image, there is no point in registering the decorator
-    if (!MarkerPinApi._images.has("Google_Maps_pin.svg"))
-      return;
-
-    MarkerPinApi._markerDecorator = new MarkerPinDecorator();
-    this.setMarkersData(markersData);
+  public static setupDecorator() {
+    return new MarkerPinDecorator();
   }
   // END SETUPDECORATOR
 
-  public static setMarkersData(markersData: MarkerData[]) {
-    if (MarkerPinApi._markerDecorator)
-      MarkerPinApi._markerDecorator.setMarkersData(markersData, this._images.get("Google_Maps_pin.svg")!);
+  public static setMarkersData(decorator: MarkerPinDecorator, markersData: MarkerData[]) {
+    if (!MarkerPinApi._images.has("Google_Maps_pin.svg"))
+      return;
+
+    decorator.setMarkersData(markersData, this._images.get("Google_Maps_pin.svg")!);
   }
 
-  public static addMarkerPoint(point: Point3d, pinImage: HTMLImageElement) {
-    if (MarkerPinApi._markerDecorator)
-      MarkerPinApi._markerDecorator.addPoint(point, pinImage);
+  public static addMarkerPoint(decorator: MarkerPinDecorator, point: Point3d, pinImage: HTMLImageElement) {
+    decorator.addPoint(point, pinImage);
   }
 
   // START ENABLEDECORATIONS
-  public static enableDecorations() {
-    if (MarkerPinApi._markerDecorator)
-      IModelApp.viewManager.addDecorator(MarkerPinApi._markerDecorator);
+  public static enableDecorations(decorator: MarkerPinDecorator) {
+    if (!IModelApp.viewManager.decorators.includes(decorator))
+      IModelApp.viewManager.addDecorator(decorator);
   }
   // END ENABLEDECORATIONS
 
-  public static disableDecorations() {
-    if (null != MarkerPinApi._markerDecorator)
-      IModelApp.viewManager.dropDecorator(MarkerPinApi._markerDecorator);
+  public static disableDecorations(decorator: MarkerPinDecorator) {
+    IModelApp.viewManager.dropDecorator(decorator);
   }
 }

--- a/src/frontend-samples/marker-pin-sample/MarkerPinApi.ts
+++ b/src/frontend-samples/marker-pin-sample/MarkerPinApi.ts
@@ -19,12 +19,15 @@ export default class MarkerPinApi {
   }
   // END SETUPDECORATOR
 
+
+  // START SETMARKERDATA
   public static setMarkersData(decorator: MarkerPinDecorator, markersData: MarkerData[]) {
     if (!MarkerPinApi._images.has("Google_Maps_pin.svg"))
       return;
 
     decorator.setMarkersData(markersData, this._images.get("Google_Maps_pin.svg")!);
   }
+  // END SETMARKERDATA
 
   public static addMarkerPoint(decorator: MarkerPinDecorator, point: Point3d, pinImage: HTMLImageElement) {
     decorator.addPoint(point, pinImage);

--- a/src/frontend-samples/marker-pin-sample/MarkerPinApi.ts
+++ b/src/frontend-samples/marker-pin-sample/MarkerPinApi.ts
@@ -19,7 +19,6 @@ export default class MarkerPinApi {
   }
   // END SETUPDECORATOR
 
-
   // START SETMARKERDATA
   public static setMarkersData(decorator: MarkerPinDecorator, markersData: MarkerData[]) {
     if (!MarkerPinApi._images.has("Google_Maps_pin.svg"))

--- a/src/frontend-samples/marker-pin-sample/MarkerPinDecorator.ts
+++ b/src/frontend-samples/marker-pin-sample/MarkerPinDecorator.ts
@@ -333,11 +333,11 @@ export class MarkerPinDecorator implements Decorator {
   /* Implement this method to add Decorations into the supplied DecorateContext. */
   public decorate(context: DecorateContext): void {
     if (!this._autoMarkerSet.viewport) {
-      this._autoMarkerSet.changeViewport(context.screenViewport)
+      this._autoMarkerSet.changeViewport(context.screenViewport);
     }
 
     if (!this._manualMarkerSet.viewport) {
-      this._manualMarkerSet.changeViewport(context.screenViewport)
+      this._manualMarkerSet.changeViewport(context.screenViewport);
     }
     /* This method is called for every rendering frame.  We will reuse our marker sets since the locations and images
        for the markers don't typically change. */

--- a/src/frontend-samples/marker-pin-sample/MarkerPinDecorator.ts
+++ b/src/frontend-samples/marker-pin-sample/MarkerPinDecorator.ts
@@ -273,7 +273,7 @@ class SampleMarkerSet extends MarkerSet<SamplePinMarker> {
   // END REMOVEMARKER
 
   /** Drop all markers from the set */
-  public clear(){
+  public clear() {
     this.markers.clear();
   }
 }
@@ -332,7 +332,13 @@ export class MarkerPinDecorator implements Decorator {
   // START DECORATE
   /* Implement this method to add Decorations into the supplied DecorateContext. */
   public decorate(context: DecorateContext): void {
+    if (!this._autoMarkerSet.viewport) {
+      this._autoMarkerSet.changeViewport(context.screenViewport)
+    }
 
+    if (!this._manualMarkerSet.viewport) {
+      this._manualMarkerSet.changeViewport(context.screenViewport)
+    }
     /* This method is called for every rendering frame.  We will reuse our marker sets since the locations and images
        for the markers don't typically change. */
     if (context.viewport.view.isSpatialView()) {

--- a/src/frontend-samples/marker-pin-sample/MarkerPinWidget.tsx
+++ b/src/frontend-samples/marker-pin-sample/MarkerPinWidget.tsx
@@ -63,6 +63,14 @@ const MarkerPinWidget: React.FunctionComponent = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  /** Initialize Decorator */
+  useEffect(() => {
+    MarkerPinApi.enableDecorations(markerPinDecorator);
+    return () => {
+      MarkerPinApi.disableDecorations(markerPinDecorator);
+    };
+  }, [markerPinDecorator]);
+
   /** When the images are loaded, initalize the MarkerPin */
   useEffect(() => {
     if (!imagesLoadedState)
@@ -73,7 +81,6 @@ const MarkerPinWidget: React.FunctionComponent = () => {
     PlaceMarkerTool.register(MarkerPinApi._sampleNamespace);
 
     MarkerPinApi.setMarkersData(markerPinDecorator, markersDataState);
-    MarkerPinApi.enableDecorations(markerPinDecorator);
 
     if (viewport)
       viewInit();
@@ -81,8 +88,6 @@ const MarkerPinWidget: React.FunctionComponent = () => {
       IModelApp.viewManager.onViewOpen.addOnce(() => viewInit());
 
     return () => {
-      MarkerPinApi.disableDecorations(markerPinDecorator);
-
       IModelApp.i18n.unregisterNamespace("marker-pin-i18n-namespace");
       IModelApp.tools.unRegister(PlaceMarkerTool.toolId);
     };

--- a/src/frontend-samples/marker-pin-sample/MarkerPinWidget.tsx
+++ b/src/frontend-samples/marker-pin-sample/MarkerPinWidget.tsx
@@ -12,7 +12,7 @@ import { imageElementFromUrl, IModelApp } from "@bentley/imodeljs-frontend";
 import { Point3d, Range2d } from "@bentley/geometry-core";
 import MarkerPinApi from "./MarkerPinApi";
 import { PlaceMarkerTool } from "./PlaceMarkerTool";
-import { MarkerData } from "./MarkerPinDecorator";
+import { MarkerData, MarkerPinDecorator } from "./MarkerPinDecorator";
 import "./MarkerPin.scss";
 
 interface ManualPinSelection {
@@ -37,7 +37,9 @@ const MarkerPinWidget: React.FunctionComponent = () => {
   const [markersDataState, setMarkersDataState] = React.useState<MarkerData[]>([]);
   const [rangeState, setRangeState] = React.useState<Range2d>(Range2d.createNull());
   const [heightState, setHeightState] = React.useState<number>(0);
-
+  const [markerPinDecorator] = React.useState<MarkerPinDecorator>(() => {
+    return MarkerPinApi.setupDecorator();
+  });
   /** Load the images on widget startup */
   useEffect(() => {
     MarkerPinApi._images = new Map();
@@ -70,8 +72,8 @@ const MarkerPinWidget: React.FunctionComponent = () => {
 
     PlaceMarkerTool.register(MarkerPinApi._sampleNamespace);
 
-    MarkerPinApi.setupDecorator(markersDataState);
-    MarkerPinApi.enableDecorations();
+    MarkerPinApi.setMarkersData(markerPinDecorator, markersDataState);
+    MarkerPinApi.enableDecorations(markerPinDecorator);
 
     if (viewport)
       viewInit();
@@ -79,8 +81,7 @@ const MarkerPinWidget: React.FunctionComponent = () => {
       IModelApp.viewManager.onViewOpen.addOnce(() => viewInit());
 
     return () => {
-      MarkerPinApi.disableDecorations();
-      MarkerPinApi._markerDecorator = undefined;
+      MarkerPinApi.disableDecorations(markerPinDecorator);
 
       IModelApp.i18n.unregisterNamespace("marker-pin-i18n-namespace");
       IModelApp.tools.unRegister(PlaceMarkerTool.toolId);
@@ -90,14 +91,15 @@ const MarkerPinWidget: React.FunctionComponent = () => {
 
   useEffect(() => {
     if (showDecoratorState)
-      MarkerPinApi.enableDecorations();
+      MarkerPinApi.enableDecorations(markerPinDecorator);
     else
-      MarkerPinApi.disableDecorations();
+      MarkerPinApi.disableDecorations(markerPinDecorator);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showDecoratorState]);
 
   useEffect(() => {
-    MarkerPinApi.setMarkersData(markersDataState);
+    MarkerPinApi.setMarkersData(markerPinDecorator, markersDataState);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [markersDataState]);
 
   const viewInit = () => {
@@ -141,7 +143,7 @@ const MarkerPinWidget: React.FunctionComponent = () => {
 
   /** This callback will be executed by the PlaceMarkerTool when it is time to create a new marker */
   const _manuallyAddMarker = (point: Point3d) => {
-    MarkerPinApi.addMarkerPoint(point, MarkerPinApi._images.get(manualPinState.image)!);
+    MarkerPinApi.addMarkerPoint(markerPinDecorator, point, MarkerPinApi._images.get(manualPinState.image)!);
   };
 
   /** This callback will be executed when the user clicks the UI button.  It will start the tool which

--- a/src/frontend-samples/marker-pin-sample/walkthru.md
+++ b/src/frontend-samples/marker-pin-sample/walkthru.md
@@ -2,9 +2,15 @@
 
 This sample implements a [View Decorator](https://www.itwinjs.org/learning/frontend/viewdecorations/) to draw [Markers](https://www.itwinjs.org/learning/frontend/markers/) which are used to call the user's attention to a particular point in space.
 
-The `setupDecorator` is called as the sample is initializing.  It is provided an array of [MarkerData](/?step=MARKERDATA) which supplies the location and title for each marker.  The method initializes the decorator object with the supplied marker data.
+The `setupDecorator` method is called as the sample is initializing.  It creates and returns an instance of a MarkerPinDecorator, which can be used to create and decorate the viewport with `Markers`.
 
 [_metadata_:annotation]:- "SETUPDECORATOR"
+
+# Setting Marker Data
+
+The `setMarkersData` method is called after the decorator is initialized, or whenever the point layout of the markers is changed.  It is provided an array of [MarkerData](/?step=MARKERDATA) which supplies the location and title for each marker.  The method provides the decorator object with the supplied marker data.
+
+[_metadata_:annotation]:- "SETMARKERDATA"
 
 # MarkerData
 

--- a/src/frontend-samples/marker-pin-sample/walkthru.md
+++ b/src/frontend-samples/marker-pin-sample/walkthru.md
@@ -6,9 +6,15 @@ The `setupDecorator` method is called as the sample is initializing.  It creates
 
 [_metadata_:annotation]:- "SETUPDECORATOR"
 
+# Add Decorator
+
+Once our Decorator is ready we need to register it with the ViewManager.  After being registered, the viewManager will call our decorator when it needs to draw decorations.
+
+[_metadata_:annotation]:- "ENABLEDECORATIONS"
+
 # Setting Marker Data
 
-The `setMarkersData` method is called after the decorator is initialized, or whenever the point layout of the markers is changed.  It is provided an array of [MarkerData](/?step=MARKERDATA) which supplies the location and title for each marker.  The method provides the decorator object with the supplied marker data.
+The `setMarkersData` method is called after the decorator is initialized, or whenever the layout of the markers is changed.  It is provided an array of [MarkerData](/?step=MARKERDATA) which supplies the location and title for each marker.  The method provides the decorator object with the supplied marker data.
 
 [_metadata_:annotation]:- "SETMARKERDATA"
 
@@ -16,12 +22,6 @@ The `setMarkersData` method is called after the decorator is initialized, or whe
 
 [_metadata_:annotation]:- "MARKERDATA"
 [_metadata_:minor]:- "true"
-
-# Add Decorator
-
-Once our Decorator is ready we need to register it with the ViewManager.  After being registered, the viewManager will call our decorator when it needs to draw decorations.
-
-[_metadata_:annotation]:- "ENABLEDECORATIONS"
 
 # Marker Pin Decorator
 

--- a/src/frontend-samples/validation-sample/ValidationApi.ts
+++ b/src/frontend-samples/validation-sample/ValidationApi.ts
@@ -30,6 +30,10 @@ export default class ValidationApi {
     return ValidationApi._requestContext;
   }
 
+  public static setupDecorator() {
+    return new MarkerPinDecorator();
+  }
+
   public static setDecoratorPoints(markersData: MarkerData[], decorator: MarkerPinDecorator, images: Map<string, HTMLImageElement>) {
     decorator.setMarkersData(markersData, images.get("clash_pin.svg")!, ValidationApi.visualizeValidationCallback);
   }

--- a/src/frontend-samples/validation-sample/ValidationWidget.tsx
+++ b/src/frontend-samples/validation-sample/ValidationWidget.tsx
@@ -15,7 +15,11 @@ const ValidationWidget: React.FunctionComponent = () => {
   const [ruleData, setRuleData] = React.useState<any>();
   const [markersData, setMarkersData] = React.useState<MarkerData[]>();
   const [images, setImages] = React.useState<Map<string, HTMLImageElement>>();
-  const [validationDecorator, setValidationDecorator] = React.useState<MarkerPinDecorator | undefined>();
+  const [validationDecorator] = React.useState<MarkerPinDecorator>(() => {
+    const decorator = new MarkerPinDecorator();
+    ValidationApi.enableDecorations(decorator);
+    return decorator
+  });
   useEffect(() => {
     const newImages = new Map();
     imageElementFromUrl(".\\clash_pin.svg").then((image) => {
@@ -44,8 +48,7 @@ const ValidationWidget: React.FunctionComponent = () => {
     }
     return () => {
       removeListener();
-      if (validationDecorator)
-        ValidationApi.disableDecorations(validationDecorator);
+      ValidationApi.disableDecorations(validationDecorator);
     };
   }, [iModelConnection, validationDecorator]);
 
@@ -63,25 +66,20 @@ const ValidationWidget: React.FunctionComponent = () => {
 
   useEffect(() => {
     if (markersData && images) {
-      const decorator = new MarkerPinDecorator();
-      ValidationApi.setDecoratorPoints(markersData, decorator, images);
-      ValidationApi.enableDecorations(decorator);
-      setValidationDecorator(decorator);
+      ValidationApi.setDecoratorPoints(markersData, validationDecorator, images);
       // Automatically visualize first clash
       if (markersData !== undefined && markersData.length !== 0 && markersData[0].data !== undefined) {
         ValidationApi.visualizeViolation(markersData[0].data.elementId);
       }
       setShowDecorator(true);
     }
-  }, [markersData, images]);
+  }, [markersData, images, validationDecorator]);
 
   useEffect(() => {
-    if (validationDecorator) {
-      if (showDecorator)
-        ValidationApi.enableDecorations(validationDecorator);
-      else
-        ValidationApi.disableDecorations(validationDecorator);
-    }
+    if (showDecorator)
+      ValidationApi.enableDecorations(validationDecorator);
+    else
+      ValidationApi.disableDecorations(validationDecorator);
   }, [showDecorator, validationDecorator]);
 
   useEffect(() => {

--- a/src/frontend-samples/validation-sample/ValidationWidget.tsx
+++ b/src/frontend-samples/validation-sample/ValidationWidget.tsx
@@ -16,10 +16,9 @@ const ValidationWidget: React.FunctionComponent = () => {
   const [markersData, setMarkersData] = React.useState<MarkerData[]>();
   const [images, setImages] = React.useState<Map<string, HTMLImageElement>>();
   const [validationDecorator] = React.useState<MarkerPinDecorator>(() => {
-    const decorator = new MarkerPinDecorator();
-    ValidationApi.enableDecorations(decorator);
-    return decorator;
+    return ValidationApi.setupDecorator();
   });
+
   useEffect(() => {
     const newImages = new Map();
     imageElementFromUrl(".\\clash_pin.svg").then((image) => {
@@ -31,6 +30,14 @@ const ValidationWidget: React.FunctionComponent = () => {
         console.error(error);
       });
   }, []);
+
+  /** Initialize Decorator */
+  useEffect(() => {
+    ValidationApi.enableDecorations(validationDecorator);
+    return () => {
+      ValidationApi.disableDecorations(validationDecorator);
+    };
+  }, [validationDecorator]);
 
   useEffect(() => {
     /** Create a listener that responds to validation data retrival */
@@ -48,9 +55,8 @@ const ValidationWidget: React.FunctionComponent = () => {
     }
     return () => {
       removeListener();
-      ValidationApi.disableDecorations(validationDecorator);
     };
-  }, [iModelConnection, validationDecorator]);
+  }, [iModelConnection]);
 
   /** When the validation data comes in, get the marker data */
   useEffect(() => {

--- a/src/frontend-samples/validation-sample/ValidationWidget.tsx
+++ b/src/frontend-samples/validation-sample/ValidationWidget.tsx
@@ -18,7 +18,7 @@ const ValidationWidget: React.FunctionComponent = () => {
   const [validationDecorator] = React.useState<MarkerPinDecorator>(() => {
     const decorator = new MarkerPinDecorator();
     ValidationApi.enableDecorations(decorator);
-    return decorator
+    return decorator;
   });
   useEffect(() => {
     const newImages = new Map();


### PR DESCRIPTION
Resolved a bug caused by a race condition between the initial view setup and the creation of the marker pin decorator that caused markers to not render correctly. MarkerSets would be created before the initial view was setup, which required them to be updated manually.

Resolved another bug, also caused by a race condition, that caused the markers in the issue sample to not update on the very first decoration frame after having either of the filters change. The fix is hacky, it uses a timer to make a call to invalidate decorations, but this bug seems to fall outside of the sample, since the correct markers are being supplied to the DecorateContext on the first call to decorate.