### PR TITLE
add frontend-devtools to list of available pkgs in the showcase/sandbox

### DIFF
--- a/Modules.json
+++ b/Modules.json
@@ -50,6 +50,10 @@
       "import": "@bentley/frontend-authorization-client"
     },
     {
+      "name": "@bentley/frontend-devtools",
+      "import": "@bentley/frontend-devtools"
+    },
+    {
       "name": "@bentley/geometry-core",
       "import": "@bentley/geometry-core"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2405,6 +2405,21 @@
         "oidc-client": "^1.9.1"
       }
     },
+    "@bentley/frontend-devtools": {
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/@bentley/frontend-devtools/-/frontend-devtools-2.19.3.tgz",
+      "integrity": "sha512-eWW+zQ0dHyFX8Xh3b72UYW805CSskWHi2UXjQSM2BzgNicr95FT21EzZnZ37i3EPUZrxR92jY5b+Mt43ySZ1DA==",
+      "requires": {
+        "@bentley/bentleyjs-core": "2.19.3",
+        "@bentley/context-registry-client": "2.19.3",
+        "@bentley/geometry-core": "2.19.3",
+        "@bentley/imodeljs-common": "2.19.3",
+        "@bentley/imodeljs-frontend": "2.19.3",
+        "@bentley/imodeljs-i18n": "2.19.3",
+        "@bentley/itwin-client": "2.19.3",
+        "file-saver": "^2.0.2"
+      }
+    },
     "@bentley/geometry-core": {
       "version": "2.19.3",
       "resolved": "https://registry.npmjs.org/@bentley/geometry-core/-/geometry-core-2.19.3.tgz",
@@ -11208,6 +11223,11 @@
           }
         }
       }
+    },
+    "file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "file-uri-to-path": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@bentley/context-registry-client": "^2.19.3",
     "@bentley/frontend-application-insights-client": "^2.19.3",
     "@bentley/frontend-authorization-client": "^2.19.3",
+    "@bentley/frontend-devtools": "^2.19.3",
     "@bentley/geometry-core": "^2.19.3",
     "@bentley/hypermodeling-frontend": "^2.19.3",
     "@bentley/icons-generic-webfont": "^1.0.15",


### PR DESCRIPTION
Was hoping to use some of the utilities in frontend-devtools in a sandbox but it wasn't avialable
It was also mentioned in a sprint review a few weeks back that this would be handy to have