### PR TITLE
Modified generate script to use relative url

### DIFF
--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -51,9 +51,9 @@ async function handleExec(source, generatedFilesDest) {
         return {
           dependency: mod.dependency,
           version: mod.version,
-          lib: mod.fileName.replace(path.join(process.cwd(), "public"), "").replace(/\\/g, "/"),
+          lib: mod.fileName.replace(path.join(process.cwd(), "public", "/"), "").replace(/\\/g, "/"),
           global: camelCase(mod.dependency),
-          types: typedef ? typedef.fileName.replace(path.join(process.cwd(), "public"), "").replace(/\\/g, "/") : undefined,
+          types: typedef ? typedef.fileName.replace(path.join(process.cwd(), "public", "/"), "").replace(/\\/g, "/") : undefined,
         }
       })
     );


### PR DESCRIPTION
Uses elative url vs absolute to resolve types and index files. Previously, using absolute urls worked locally but fails in dev/qa.